### PR TITLE
Create datastore for video stream data

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -46,8 +46,8 @@ import (
 	"github.com/gofiber/fiber/v2"
 )
 
-// RegisterAPIRoutes registers all handler functions to their routes.
-func RegisterAPIRoutes(app *fiber.App) {
+// registerAPIRoutes registers all handler functions to their routes.
+func registerAPIRoutes(app *fiber.App) {
 
 	v1 := app.Group("/api/v1")
 
@@ -61,6 +61,11 @@ func RegisterAPIRoutes(app *fiber.App) {
 	// Video streams.
 	v1.Get("/videostreams/:id", handlers.GetVideoStreamByID)
 	v1.Get("/videostreams", handlers.GetVideoStreams)
+	v1.Post("/videostreams/live", handlers.StartVideoStream)
+	v1.Patch("/videostreams/:id/live", handlers.EndVideoStream)
+	v1.Post("/videostreams", handlers.CreateVideoStream)
+	v1.Patch("/videostreams/:id", handlers.UpdateVideoStream)
+	v1.Delete("/videostreams/:id", handlers.DeleteVideoStream)
 
 	// Annotations.
 	v1.Get("/annotations/:id", handlers.GetAnnotationByID)
@@ -98,6 +103,6 @@ func main() {
 	// Start web server.
 	fmt.Println("starting web server")
 	app := fiber.New(fiber.Config{ErrorHandler: errorHandler})
-	RegisterAPIRoutes(app)
+	registerAPIRoutes(app)
 	app.Listen(":3000")
 }

--- a/api/capturesource_test.go
+++ b/api/capturesource_test.go
@@ -68,8 +68,8 @@ func TestCreateCaptureSource(t *testing.T) {
 
 	// Initialize app.
 	ds_client.Init(false)
-	app := fiber.New()
-	RegisterAPIRoutes(app)
+	app := fiber.New(fiber.Config{ErrorHandler: errorHandler})
+	registerAPIRoutes(app)
 
 	for i, testcase := range testcases {
 		// Send test request.
@@ -92,8 +92,8 @@ func TestGetCaptureSourcesWithLimitAndOffset(t *testing.T) {
 
 	// Initialize app.
 	ds_client.Init(false)
-	app := fiber.New()
-	RegisterAPIRoutes(app)
+	app := fiber.New(fiber.Config{ErrorHandler: errorHandler})
+	registerAPIRoutes(app)
 
 	// Populate datastore with test data.
 	for _, body := range []string{

--- a/api/handlers/annotations.go
+++ b/api/handlers/annotations.go
@@ -44,8 +44,8 @@ import (
 
 // TimeSpan is the JSON format for a pair of timestamps - start time and end time.
 type TimeSpan struct {
-	From time.Time `json:"from"`
-	To   time.Time `json:"to"`
+	Start time.Time `json:"start" query:"start"`
+	End   time.Time `json:"end" query:"end"`
 }
 
 // BoundingBox is the json format for a rectangle enclosing something interesting in a video.

--- a/api/handlers/videostream.go
+++ b/api/handlers/videostream.go
@@ -35,9 +35,15 @@ LICENSE
 package handlers
 
 import (
+	"context"
+	"errors"
+	"strconv"
 	"time"
 
 	"github.com/ausocean/openfish/api/api"
+	"github.com/ausocean/openfish/api/ds_client"
+	"github.com/ausocean/openfish/api/model"
+	"github.com/ausocean/openfish/datastore"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -45,30 +51,100 @@ import (
 // VideoStreamResult  describes the JSON format for video streams in API responses.
 // Fields use pointers because they are optional (this is what the format URL param is for).
 type VideoStreamResult struct {
-	ID        *int           `json:"id,omitempty"`
-	Datetime  *time.Time     `json:"datetime,omitempty"`
-	Duration  *time.Duration `json:"duration,omitempty"`
-	StreamUrl *string        `json:"streamUrl,omitempty"`
+	ID            *int64     `json:"id,omitempty"`
+	StartTime     *time.Time `json:"startTime,omitempty"`
+	EndTime       *time.Time `json:"endTime,omitempty"`
+	StreamUrl     *string    `json:"stream_url,omitempty"`
+	CaptureSource *int64     `json:"capturesource,omitempty"`
+}
+
+// FromVideoStream creates a VideoStreamResult from a model.VideoStream and key, formatting it according to the requested format.
+func FromVideoStream(videoStream *model.VideoStream, id int64, format *api.Format) VideoStreamResult {
+	var result VideoStreamResult
+	if format.Requires("id") {
+		result.ID = &id
+	}
+	if format.Requires("start_time") {
+		result.StartTime = &videoStream.StartTime
+	}
+	if format.Requires("end_time") {
+		result.EndTime = videoStream.EndTime
+	}
+	if format.Requires("stream_url") {
+		result.StreamUrl = &videoStream.StreamUrl
+	}
+	if format.Requires("capturesource") {
+		result.CaptureSource = &videoStream.CaptureSource
+	}
+	return result
 }
 
 // GetVideoStreamsQuery describes the URL query parameters required for the GetVideoStreams endpoint.
 type GetVideoStreamsQuery struct {
-	TimeSpan      *string `query:"timespan"`       // Optional. TODO: choose more appropriate type.
-	CaptureSource *int64  `query:"capture_source"` // Optional.
+	CaptureSource *int64    `query:"capturesource"` // Optional.
+	TimeSpan      *TimeSpan `query:"timespan"`      // Optional.
 	api.LimitAndOffset
-	api.Format
+}
+
+// CreateVideoStreamBody describes the JSON format required for the CreateVideoStream endpoint.
+//
+// ID is omitted because it is chosen automatically.
+type CreateVideoStreamBody struct {
+	StartTime     time.Time `json:"startTime"`
+	EndTime       time.Time `json:"endTime"`
+	StreamUrl     string    `json:"stream_url"`
+	CaptureSource int64     `json:"capturesource"`
+}
+
+// StartVideoStreamBody describes the JSON format required for the StartVideoStream endpoint.
+//
+// ID is omitted because it is chosen automatically.
+// Datetime is omitted because it uses the current time.
+// Duration is omitted because it will be set once the stream concludes.
+type StartVideoStreamBody struct {
+	StreamUrl     string `json:"stream_url"`
+	CaptureSource int64  `json:"capturesource"`
+}
+
+// UpdateVideoStreamBody describes the JSON format required for the UpdateVideoStream endpoint.
+type UpdateVideoStreamBody struct {
+	StartTime     *time.Time `json:"startTime"`     // Optional.
+	EndTime       *time.Time `json:"endTime"`       // Optional.
+	StreamUrl     *string    `json:"stream_url"`    // Optional.
+	CaptureSource *int64     `json:"capturesource"` // Optional.
 }
 
 // GetVideoStreamByID gets a video stream when provided with an ID.
 func GetVideoStreamByID(ctx *fiber.Ctx) error {
-	// TODO: implement handler
+	// Parse URL.
+	format := new(api.Format)
 
-	// id, _ := ctx.ParamsInt("id", 1)
-	return ctx.JSON("TODO")
+	if err := ctx.QueryParser(format); err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	id, err := strconv.ParseInt(ctx.Params("id"), 10, 64)
+	if err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	// Fetch data from the datastore.
+	store := ds_client.Get()
+	key := store.IDKey("VideoStream", id)
+	var videoStream model.VideoStream
+	if store.Get(context.Background(), key, &videoStream) != nil {
+		return api.DatastoreReadFailure(err)
+	}
+
+	// Format result.
+	result := FromVideoStream(&videoStream, id, format)
+
+	return ctx.JSON(result)
 }
 
 // GetVideoStreams gets a list of video streams, filtering by timespan, capture source if specified.
 func GetVideoStreams(ctx *fiber.Ctx) error {
+	// Parse URL.
 	qry := new(GetVideoStreamsQuery)
 	qry.SetLimit()
 
@@ -76,13 +152,226 @@ func GetVideoStreams(ctx *fiber.Ctx) error {
 		return api.InvalidRequestURL(err)
 	}
 
-	// Placeholder code: returns an empty result.
-	// TODO: implement fetching from datastore.
-	result := api.Result[VideoStreamResult]{
-		Results: []VideoStreamResult{},
+	format := new(api.Format)
+	if err := ctx.QueryParser(format); err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	// Fetch data from the datastore.
+	store := ds_client.Get()
+	query := store.NewQuery("VideoStream", false)
+
+	// Filter by timespan (database side).
+	if qry.TimeSpan != nil {
+		// Validate timespan
+		if qry.TimeSpan.Start.After(qry.TimeSpan.End) {
+			return api.InvalidRequestURL(errors.New("start time not before end time"))
+		}
+
+		// BUG: Because of a limitation of google cloud's datastore, we can only use inequality filters on one
+		// field at a time. This query needs to filter out videostreams that started after the specified range.
+		// https://github.com/ausocean/openfish/issues/23
+		query.FilterField("EndTime", ">=", qry.TimeSpan.Start)
+	}
+
+	// Filter by capture source.
+	if qry.CaptureSource != nil {
+		query.FilterField("CaptureSource", "=", *qry.CaptureSource)
+	}
+
+	query.Limit(qry.Limit)
+	query.Offset(qry.Offset)
+
+	var videoStreams []model.VideoStream
+	keys, err := store.GetAll(context.Background(), query, &videoStreams)
+	if err != nil {
+		return api.DatastoreReadFailure(err)
+	}
+
+	// Format results.
+	results := make([]VideoStreamResult, len(videoStreams))
+	for i := range videoStreams {
+		results[i] = FromVideoStream(&videoStreams[i], keys[i].ID, format)
+	}
+
+	return ctx.JSON(api.Result[VideoStreamResult]{
+		Results: results,
 		Offset:  qry.Offset,
 		Limit:   qry.Limit,
-		Total:   0,
+		Total:   len(results),
+	})
+}
+
+// putVideoStream puts a video stream in the datastore, checking if the capture source exists.
+func putVideoStream(ctx *fiber.Ctx, vs model.VideoStream) (int64, error) {
+	// Verify CaptureSource exists.
+	store := ds_client.Get()
+	key := store.IDKey("CaptureSource", vs.CaptureSource)
+	var captureSource model.CaptureSource
+
+	err := store.Get(context.Background(), key, &captureSource)
+	if err != nil {
+		return 0, api.DatastoreReadFailure(err)
 	}
-	return ctx.JSON(result)
+
+	// Get a unique ID for the new video stream.
+	key = store.IncompleteKey("VideoStream")
+
+	key, err = store.Put(context.Background(), key, &vs)
+	if err != nil {
+		print(err.Error())
+		return 0, api.DatastoreWriteFailure(err)
+	}
+
+	// Return ID of created video stream.
+	return key.ID, nil
+
+}
+
+// CreateVideoStream creates a new video stream.
+// BUG: start and end time are required but this is not being enforced.
+// https://github.com/ausocean/openfish/issues/18
+func CreateVideoStream(ctx *fiber.Ctx) error {
+	var body CreateVideoStreamBody
+	err := ctx.BodyParser(&body)
+	if err != nil {
+		return api.InvalidRequestJSON(err)
+	}
+
+	// Create video stream entity and add to the datastore.
+	vs := model.VideoStream{
+		StartTime:     body.StartTime,
+		EndTime:       &body.EndTime,
+		StreamUrl:     body.StreamUrl,
+		CaptureSource: body.CaptureSource,
+	}
+	id, err := putVideoStream(ctx, vs)
+	if err != nil {
+		return err
+	}
+
+	// Return ID of created video stream.
+	return ctx.JSON(VideoStreamResult{
+		ID: &id,
+	})
+}
+
+// StartVideoStream creates a new video stream at the current time.
+func StartVideoStream(ctx *fiber.Ctx) error {
+	now := time.Now()
+
+	var body StartVideoStreamBody
+	err := ctx.BodyParser(&body)
+	if err != nil {
+		return api.InvalidRequestJSON(err)
+	}
+
+	// Create video stream entity and add to the datastore.
+	vs := model.VideoStream{
+		StartTime:     now,
+		StreamUrl:     body.StreamUrl,
+		CaptureSource: body.CaptureSource,
+	}
+	id, err := putVideoStream(ctx, vs)
+	if err != nil {
+		return err
+	}
+
+	// Return ID of created video stream.
+	return ctx.JSON(VideoStreamResult{
+		ID: &id,
+	})
+}
+
+// EndVideoStream updates the video stream's duration.
+func EndVideoStream(ctx *fiber.Ctx) error {
+	now := time.Now()
+
+	// Parse URL.
+	id, err := strconv.ParseInt(ctx.Params("id"), 10, 64)
+	if err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	// Update data in the datastore.
+	store := ds_client.Get()
+	key := store.IDKey("VideoStream", id)
+	var videoStream model.VideoStream
+
+	err = store.Update(context.Background(), key, func(e datastore.Entity) {
+		v, ok := e.(*model.VideoStream)
+		if ok {
+			v.EndTime = &now
+		}
+	}, &videoStream)
+	if err != nil {
+		return api.DatastoreReadFailure(err)
+	}
+
+	return nil
+}
+
+// UpdateVideoStream updates a video stream.
+func UpdateVideoStream(ctx *fiber.Ctx) error {
+	// Parse URL.
+	id, err := strconv.ParseInt(ctx.Params("id"), 10, 64)
+	if err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	// Parse body.
+	var body UpdateVideoStreamBody
+	if ctx.BodyParser(&body) != nil {
+		return api.InvalidRequestJSON(err)
+	}
+
+	// Update data in the datastore.
+	store := ds_client.Get()
+	key := store.IDKey("VideoStream", id)
+	var videoStream model.VideoStream
+
+	err = store.Update(context.Background(), key, func(e datastore.Entity) {
+		v, ok := e.(*model.VideoStream)
+		if ok {
+			if body.StartTime != nil {
+				v.StartTime = *body.StartTime
+			}
+			if body.EndTime != nil {
+				v.EndTime = body.EndTime
+			}
+			if body.CaptureSource != nil {
+				v.CaptureSource = *body.CaptureSource
+			}
+			if body.StreamUrl != nil {
+				v.StreamUrl = *body.StreamUrl
+			}
+		}
+	}, &videoStream)
+	if err != nil {
+		return api.DatastoreReadFailure(err)
+	}
+
+	return nil
+}
+
+// DeleteVideoStream deletes a video stream.
+// BUG: endpoint returns 200 ok for nonexistent IDs.
+// https://github.com/ausocean/openfish/issues/17
+func DeleteVideoStream(ctx *fiber.Ctx) error {
+	// Parse URL.
+	id, err := strconv.ParseInt(ctx.Params("id"), 10, 64)
+	if err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	// Delete entity.
+	store := ds_client.Get()
+	key := store.IDKey("VideoStream", id)
+
+	if store.Delete(context.Background(), key) != nil {
+		return api.DatastoreWriteFailure(err)
+	}
+
+	return nil
+
 }

--- a/api/model/videostream.go
+++ b/api/model/videostream.go
@@ -1,0 +1,62 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package model
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// VideoStream holds the information about a single video stream.
+// VideoStream contains the url for a live or completed stream off of youtube, the start time,
+// the end time (unless it is still ongoing), and the ID of its capture source.
+// In the future, it will also contain data about how to retrieve the video data from the cloud.
+type VideoStream struct {
+	StartTime     time.Time
+	EndTime       *time.Time // Optional.
+	StreamUrl     string
+	CaptureSource int64
+	// TODO: Add cloud storage location.
+}
+
+// Encode serializes VideoStream. Implements Entity interface. Used for FileStore datastore.
+func (vs *VideoStream) Encode() []byte {
+	bytes, _ := json.Marshal(vs)
+	return bytes
+}
+
+// Encode deserializes VideoStream. Implements Entity interface. Used for FileStore datastore.
+func (vs *VideoStream) Decode(b []byte) error {
+	return json.Unmarshal(b, vs)
+}

--- a/api/videostream_test.go
+++ b/api/videostream_test.go
@@ -15,8 +15,8 @@ import (
 func setup(t *testing.T) (*fiber.App, int64) {
 	// Initialize app.
 	ds_client.Init(false)
-	app := fiber.New()
-	RegisterAPIRoutes(app)
+	app := fiber.New(fiber.Config{ErrorHandler: errorHandler})
+	registerAPIRoutes(app)
 
 	// Populate datastore with capturesource for testing.
 	// Send test request.


### PR DESCRIPTION
Resolves issue #5 

Adds support for creating video streams (such as uploading past streams), and starting and finishing live streams.
Adds support for updating and deleting existing streams.
Adds support for fetching video stream, filtering by capture source or by timespan

API test changes have been split off into a separate PR #14 
Error handling improvements have been split off into a separate PR #15