### PR TITLE
Use error handler func to simplify error handling

### DIFF
--- a/api/api/result_types.go
+++ b/api/api/result_types.go
@@ -33,7 +33,11 @@ LICENSE
 
 package api
 
-import "github.com/gofiber/fiber/v2"
+import (
+	"fmt"
+
+	"github.com/gofiber/fiber/v2"
+)
 
 // Result is the JSON format to use in response bodies for returning a list of results.
 type Result[T any] struct {
@@ -44,35 +48,26 @@ type Result[T any] struct {
 }
 
 // Failure is the JSON format to use in response bodies for returning errors.
-// TODO: Add second field with additional details, to help with debugging.
 type Failure struct {
 	Message string `json:"message"`
 }
 
-// DatastoreReadFailure sets HTTP status code and JSON for datastore read failure.
-func DatastoreReadFailure(ctx *fiber.Ctx) error {
-	return ctx.
-		Status(fiber.StatusInternalServerError).
-		JSON(Failure{Message: "could not read from datastore"})
+// DatastoreReadFailure returns an error for datastore read failures.
+func DatastoreReadFailure(err error) error {
+	return fiber.NewError(500, fmt.Errorf("could not read from datastore: %w", err).Error())
 }
 
-// DatastoreWriteFailure sets HTTP status code and JSON for datastore write failure.
-func DatastoreWriteFailure(ctx *fiber.Ctx) error {
-	return ctx.
-		Status(fiber.StatusInternalServerError).
-		JSON(Failure{Message: "could not write to datastore"})
+// DatastoreWriteFailure returns an error for datastore write failures.
+func DatastoreWriteFailure(err error) error {
+	return fiber.NewError(500, fmt.Errorf("could not write to datastore: %w", err).Error())
 }
 
-// InvalidRequestJSON sets HTTP status code and JSON for requests with invalid JSON.
-func InvalidRequestJSON(ctx *fiber.Ctx) error {
-	return ctx.
-		Status(fiber.StatusBadRequest).
-		JSON(Failure{Message: "invalid json in request"})
+// InvalidRequestJSON returns an error for requests with invalid JSON.
+func InvalidRequestJSON(err error) error {
+	return fiber.NewError(400, fmt.Errorf("invalid JSON in request: %w", err).Error())
 }
 
-// InvalidRequestURL sets HTTP status code and JSON for requests with invalid URLs.
-func InvalidRequestURL(ctx *fiber.Ctx) error {
-	return ctx.
-		Status(fiber.StatusBadRequest).
-		JSON(Failure{Message: "invalid URL in request"})
+// InvalidRequestURL returns an error for requests with invalid URLs.
+func InvalidRequestURL(err error) error {
+	return fiber.NewError(400, fmt.Errorf("invalid URL in request: %w", err).Error())
 }

--- a/api/handlers/annotations.go
+++ b/api/handlers/annotations.go
@@ -88,7 +88,7 @@ func GetAnnotations(ctx *fiber.Ctx) error {
 	qry.SetLimit()
 
 	if err := ctx.QueryParser(qry); err != nil {
-		return api.InvalidRequestURL(ctx)
+		return api.InvalidRequestURL(err)
 	}
 
 	// Placeholder code: returns an empty result.

--- a/api/handlers/capturesource.go
+++ b/api/handlers/capturesource.go
@@ -103,12 +103,12 @@ func GetCaptureSourceByID(ctx *fiber.Ctx) error {
 	format := new(api.Format)
 
 	if err := ctx.QueryParser(format); err != nil {
-		return api.InvalidRequestURL(ctx)
+		return api.InvalidRequestURL(err)
 	}
 
 	id, err := strconv.ParseInt(ctx.Params("id"), 10, 64)
 	if err != nil {
-		return api.InvalidRequestURL(ctx)
+		return api.InvalidRequestURL(err)
 	}
 
 	// Fetch data from the datastore.
@@ -116,7 +116,7 @@ func GetCaptureSourceByID(ctx *fiber.Ctx) error {
 	key := store.IDKey("CaptureSource", id)
 	var captureSource model.CaptureSource
 	if store.Get(context.Background(), key, &captureSource) != nil {
-		return api.DatastoreReadFailure(ctx)
+		return api.DatastoreReadFailure(err)
 	}
 
 	// Format result.
@@ -132,12 +132,12 @@ func GetCaptureSources(ctx *fiber.Ctx) error {
 	qry.SetLimit()
 
 	if err := ctx.QueryParser(qry); err != nil {
-		return api.InvalidRequestURL(ctx)
+		return api.InvalidRequestURL(err)
 	}
 
 	format := new(api.Format)
 	if err := ctx.QueryParser(format); err != nil {
-		return api.InvalidRequestURL(ctx)
+		return api.InvalidRequestURL(err)
 	}
 
 	// Fetch data from the datastore.
@@ -156,7 +156,7 @@ func GetCaptureSources(ctx *fiber.Ctx) error {
 	var captureSources []model.CaptureSource
 	keys, err := store.GetAll(context.Background(), query, &captureSources)
 	if err != nil {
-		return api.DatastoreReadFailure(ctx)
+		return api.DatastoreReadFailure(err)
 	}
 
 	// Format results.
@@ -179,7 +179,7 @@ func CreateCaptureSource(ctx *fiber.Ctx) error {
 
 	err := ctx.BodyParser(&body)
 	if err != nil {
-		return api.InvalidRequestJSON(ctx)
+		return api.InvalidRequestJSON(err)
 	}
 
 	// Parse location.
@@ -203,7 +203,7 @@ func CreateCaptureSource(ctx *fiber.Ctx) error {
 	key, err = store.Put(context.Background(), key, &cs)
 	if err != nil {
 		print(err.Error())
-		return api.DatastoreWriteFailure(ctx)
+		return api.DatastoreWriteFailure(err)
 	}
 
 	// Return ID of created capture source.

--- a/api/handlers/videostream.go
+++ b/api/handlers/videostream.go
@@ -73,7 +73,7 @@ func GetVideoStreams(ctx *fiber.Ctx) error {
 	qry.SetLimit()
 
 	if err := ctx.QueryParser(qry); err != nil {
-		return api.InvalidRequestURL(ctx)
+		return api.InvalidRequestURL(err)
 	}
 
 	// Placeholder code: returns an empty result.


### PR DESCRIPTION
Resolves Issue #15 

This uses a custom error handler to construct HTTP responses with a JSON body of {"message": "<>"} and with a custom HTTP status code (or 500 if it is not supplied).

Advantages of this method is it simplifies result_types.go, and unhandled errors will also be formatted nicely. The reason behind JSON formatted responses and control over HTTP status codes is that it will make it easier for client code to consume and understand errors from our API


### Examples:
**old:**
```
HTTP/1.1 400 Bad Request
Date: Wed, 21 Jun 2023 03:47:31 GMT
Content-Type: application/json
Content-Length: 37
Connection: close

{
  "message": "invalid json in request"
}
```
**new:**
```
HTTP/1.1 400 Bad Request
Date: Wed, 21 Jun 2023 03:46:02 GMT
Content-Type: application/json
Content-Length: 103
Connection: close

{
  "message": "invalid JSON in request: invalid character '}' looking for beginning of object key string"
}
```

*New error message contains information missing in old message*

**old:**
```
HTTP/1.1 405 Method Not Allowed
Date: Wed, 21 Jun 2023 03:48:07 GMT
Content-Type: text/plain; charset=utf-8
Content-Length: 18
Allow: GET, HEAD
Connection: close

Method Not Allowed
```
**new:**
```
HTTP/1.1 405 Method Not Allowed
Date: Wed, 21 Jun 2023 03:52:13 GMT
Content-Type: application/json
Content-Length: 32
Allow: GET, HEAD
Connection: close

{
  "message": "Method Not Allowed"
}
```

*New error message is JSON and consistent with other error message formats so it can be used by clients*


