### PR TITLE
Use datastore ancestor for relationships between entities

### DIFF
--- a/api/model/annotations.go
+++ b/api/model/annotations.go
@@ -53,7 +53,6 @@ type BoundingBox struct {
 
 // An Annotation holds information about observations at a particular moment and region within a video stream.
 type Annotation struct {
-	VideoStreamID    int
 	TimeSpan         TimeSpan
 	BoundingBox      *BoundingBox // Optional.
 	Observer         string

--- a/api/model/videostream.go
+++ b/api/model/videostream.go
@@ -43,10 +43,9 @@ import (
 // the end time (unless it is still ongoing), and the ID of its capture source.
 // In the future, it will also contain data about how to retrieve the video data from the cloud.
 type VideoStream struct {
-	StartTime     time.Time
-	EndTime       *time.Time // Optional.
-	StreamUrl     string
-	CaptureSource int64
+	StartTime time.Time
+	EndTime   *time.Time // Optional.
+	StreamUrl string
 	// TODO: Add cloud storage location.
 }
 


### PR DESCRIPTION
Uses ancestors for creating the relationships between entities. This makes the code simpler, and we do not need to enforce consistency, because google datastore will do it for us.