### PR TITLE
Plugin system for video streams

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ausocean/openfish/api/api"
 	"github.com/ausocean/openfish/api/ds_client"
 	"github.com/ausocean/openfish/api/handlers"
+	"github.com/ausocean/openfish/api/plugins"
 
 	"flag"
 	"fmt"
@@ -61,6 +62,7 @@ func registerAPIRoutes(app *fiber.App) {
 	// Video streams.
 	v1.Get("/videostreams/:id", handlers.GetVideoStreamByID)
 	v1.Get("/videostreams", handlers.GetVideoStreams)
+	v1.Get("/videostreams/:id/media", handlers.GetVideoStreamMedia)
 	v1.Post("/videostreams/live", handlers.StartVideoStream)
 	v1.Patch("/videostreams/:id/live", handlers.EndVideoStream)
 	v1.Post("/videostreams", handlers.CreateVideoStream)
@@ -99,6 +101,9 @@ func main() {
 	// Datastore setup.
 	fmt.Println("creating datastore (local mode: ", *local, ")")
 	ds_client.Init(*local)
+
+	// Plugin setup.
+	plugins.Init()
 
 	// Start web server.
 	fmt.Println("starting web server")

--- a/api/api/result_types.go
+++ b/api/api/result_types.go
@@ -71,3 +71,8 @@ func InvalidRequestJSON(err error) error {
 func InvalidRequestURL(err error) error {
 	return fiber.NewError(400, fmt.Errorf("invalid URL in request: %w", err).Error())
 }
+
+// NotImplemented returns an error for server code that has not been implemented yet.
+func NotImplemented() error {
+	return fiber.NewError(501, "API not implemented")
+}

--- a/api/handlers/annotations.go
+++ b/api/handlers/annotations.go
@@ -88,6 +88,12 @@ func FromAnnotation(annotation *model.Annotation, id int, format *api.Format) An
 	return result
 }
 
+// BoundingBox is the json format for a rectangle enclosing something interesting in a video.
+// It is represented using two x y coordinates, top left corner and bottom right corner of the rectangle.
+type BoundingBox struct {
+	x1, x2, y1, y2 int
+}
+
 // GetAnnotationsQuery describes the URL query parameters required for the GetAnnotations endpoint.
 type GetAnnotationsQuery struct {
 	TimeSpan      *string           `query:"timespan"`       // Optional. TODO: choose more appropriate type.

--- a/api/plugins/plugins.go
+++ b/api/plugins/plugins.go
@@ -1,0 +1,19 @@
+package plugins
+
+import (
+	"net/url"
+
+	"github.com/ausocean/openfish/api/model"
+	"github.com/gofiber/fiber/v2"
+)
+
+type VideoProviderPlugin interface {
+	Get(ctx *fiber.Ctx, streamURL *url.URL, timespan model.TimeSpan) error
+}
+
+var VideoProviderPlugins map[string]VideoProviderPlugin
+
+func Init() {
+	VideoProviderPlugins = make(map[string]VideoProviderPlugin)
+	VideoProviderPlugins["vidgrind.ausocean.org"] = VidgrindProvider{}
+}

--- a/api/plugins/vidgrind.go
+++ b/api/plugins/vidgrind.go
@@ -1,0 +1,31 @@
+package plugins
+
+import (
+	"fmt"
+	"net/url"
+
+	"github.com/ausocean/openfish/api/model"
+	"github.com/gofiber/fiber/v2"
+)
+
+type VidgrindProvider struct{}
+
+func (vg VidgrindProvider) Get(ctx *fiber.Ctx, streamURL *url.URL, timespan model.TimeSpan) error {
+
+	// Validate Stream URL.
+	qry := streamURL.Query()
+	_, ok := qry["id"]
+	if !ok {
+		panic("TODO")
+	}
+
+	// Add timestamp and duration to stream URL.
+	// TODO: remove timestamp placeholders.
+	qry.Add("ts", fmt.Sprintf("%d,%d", 1594547570, 10))
+	streamURL.RawQuery = qry.Encode()
+
+	// TODO: Add authorisation
+
+	// Redirect to vidgrind's API for serving video.
+	return ctx.Redirect(streamURL.String())
+}


### PR DESCRIPTION
Closes #27 

Adds ability to get video for a videostream using the `/api/v1/videostream/<id>/media` URL. 

Currently work in progress - need to sort out vidgrind authentication for the vidgrind plugin