### PR TITLE
Fix CORS issue

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -44,6 +44,7 @@ import (
 	"fmt"
 
 	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cors"
 )
 
 // registerAPIRoutes registers all handler functions to their routes.
@@ -103,6 +104,10 @@ func main() {
 	// Start web server.
 	fmt.Println("starting web server")
 	app := fiber.New(fiber.Config{ErrorHandler: errorHandler})
+
+	app.Use(cors.New(cors.Config{
+		AllowOrigins: "*",
+	}))
 	registerAPIRoutes(app)
 	app.Listen(":3000")
 }

--- a/api/handlers/videostream.go
+++ b/api/handlers/videostream.go
@@ -132,7 +132,8 @@ func GetVideoStreamByID(ctx *fiber.Ctx) error {
 	store := ds_client.Get()
 	key := store.IDKey("VideoStream", id)
 	var videoStream model.VideoStream
-	if store.Get(context.Background(), key, &videoStream) != nil {
+	err = store.Get(context.Background(), key, &videoStream)
+	if err != nil {
 		return api.DatastoreReadFailure(err)
 	}
 

--- a/api/model/annotations.go
+++ b/api/model/annotations.go
@@ -41,14 +41,17 @@ import (
 
 // TimeSpan is a pair of timestamps - start time and end time.
 type TimeSpan struct {
-	Start time.Time
-	End   time.Time
+	Start time.Time `json:"start"`
+	End   time.Time `json:"end"`
 }
 
 // BoundingBox is a rectangle enclosing something interesting in a video.
 // It is represented using two x y coordinates, top left corner and bottom right corner of the rectangle.
 type BoundingBox struct {
-	X1, X2, Y1, Y2 int
+	X1 int `json:"x1"`
+	X2 int `json:"x2"`
+	Y1 int `json:"y1"`
+	Y2 int `json:"y2"`
 }
 
 // An Annotation holds information about observations at a particular moment and region within a video stream.


### PR DESCRIPTION
The openfish API did not include the correct headers for the web browser, causing a CORS issue. This is because localhost:3000 and localhost:3333 / localhost:80 used by the web app are different origins, and so the browser sees this as a security issue if you do not say otherwise with AllowOrigins headers.