### PR TITLE
Add docker support

### DIFF
--- a/openfish-webapp/.dockerignore
+++ b/openfish-webapp/.dockerignore
@@ -1,0 +1,3 @@
+**/node_modules
+**/dist
+Dockerfile

--- a/openfish-webapp/Dockerfile
+++ b/openfish-webapp/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:20.5-alpine as build-stage
+WORKDIR /app
+RUN npm install -g pnpm
+COPY package*.json ./
+RUN pnpm i
+COPY ./ .
+RUN pnpm build
+
+FROM nginx as production-stage
+RUN mkdir /app
+COPY --from=build-stage /app/dist /usr/share/nginx/html

--- a/openfish-webapp/README.md
+++ b/openfish-webapp/README.md
@@ -1,19 +1,42 @@
 # Openfish Webapp
 Openfish Webapp is a web interface for interacting with the Openfish API.
 
+## Deploying openfish
+1) Build and run the web app using docker:
+   ```bash
+   docker build ./openfish-webapp -t openfish
+   docker run -p 80:80 openfish 
+   ```
+2) Start go server:
+   ```bash
+   go run ./api/ 
+   ```
+3) Open the browser and visit http://localhost.
+
 ## Development guide
 #### Getting started
 
-Run the commands:
-```
-cd openfish-webapp
-pnpm i
-```
+Have the following prerequisites installed on your system:
+- node v19.2.0 or later
+- pnpm v8.5.1 or later
+- go 1.20 or later
 
+1) Start go server:
+   ```bash
+   go run ./api/ 
+   ```
 
-#### Live development server
+2) Install all dependencies in package.json:
+   ```bash
+   cd openfish-webapp
+   pnpm i
+   ```
 
-Run `pnpm dev`, then visit http://localhost:5173/. Changes are updated live.
+3) Start the live development server:
+   ```bash
+   pnpm dev
+   ```
+   Visit http://localhost:5173/. Changes are updated live.
 
 #### Linting / formatting
 - `pnpm fmt` to format code.


### PR DESCRIPTION
Adds docker support for the web app

The docker file uses a node 20.5 image for building the web app using vite, and then a second image using nginx as the http server