### PR TITLE
Make the webapp a multi-page application

### DIFF
--- a/openfish-webapp/index.html
+++ b/openfish-webapp/index.html
@@ -6,15 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenFish</title>
     <link rel="stylesheet" href="./src/index.css" />
-    <script type="module" src="/src/app.ts"></script>
-    <script type="module" src="/src/annotation-card.ts"></script>
-    <script type="module" src="/src/video-player.ts"></script>
-    <script type="module" src="/src/playback-controls.ts"></script>
-    <script type="module" src="/src/youtube-player.ts"></script>
   </head>
   <body>
-    <openfish-app/>
+    Placeholder home page
   </body>
 </html>
-
-

--- a/openfish-webapp/src/index.css
+++ b/openfish-webapp/src/index.css
@@ -63,8 +63,3 @@ body {
   width: 100vw;
   height: 100vh;
 }
-
-openfish-app {
-  width: min(100vw, 95rem);
-  height: 100vh;
-}

--- a/openfish-webapp/vite.config.ts
+++ b/openfish-webapp/vite.config.ts
@@ -1,0 +1,14 @@
+// vite.config.js
+import { resolve } from 'path'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        index: resolve(__dirname, 'index.html'),
+        watch: resolve(__dirname, 'watch.html'),
+      },
+    },
+  },
+})

--- a/openfish-webapp/watch.html
+++ b/openfish-webapp/watch.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenFish | Watch</title>
+    <link rel="stylesheet" href="./src/index.css" />
+    <script type="module" src="/src/watch-stream.ts"></script>
+    <script type="module" src="/src/annotation-card.ts"></script>
+    <script type="module" src="/src/video-player.ts"></script>
+    <script type="module" src="/src/playback-controls.ts"></script>
+    <script type="module" src="/src/youtube-player.ts"></script>
+  </head>
+  <body>
+    <watch-stream />
+  </body>
+</html>
+
+


### PR DESCRIPTION
Closes issue #66 

The OpenFish web application for viewing videostreams will need to support additional pages, but the vite project is currently set up for just a single page (index.html). 

This PR changes it so we can add new pages. The url for viewing streams is now:
`localhost:5173/watch.html?id=<Video-stream ID>`