### PR TITLE
Add list of streams on /streams.html page

### DIFF
--- a/openfish-webapp/src/annotation-card.ts
+++ b/openfish-webapp/src/annotation-card.ts
@@ -2,6 +2,7 @@ import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import { Annotation } from './api.types.ts'
 import { repeat } from 'lit/directives/repeat.js'
+import { formatAsDate, formatAsTime, formatAsTimeZone } from './datetime.ts'
 
 /**
  * TODO: write component documentation
@@ -27,32 +28,12 @@ export class AnnotationCard extends LitElement {
     const start = new Date(this.annotation.timespan.start)
     const end = new Date(this.annotation.timespan.end)
     const duration = (end.getTime() - start.getTime()) / 1000
-    const tz = new Intl.DateTimeFormat('en-AU', { day: '2-digit', timeZoneName: 'short' })
-      .format(start)
-      .slice(4)
+    const tz = formatAsTimeZone(start)
 
-    const startDate = new Intl.DateTimeFormat('en-AU', {
-      weekday: 'short',
-      year: 'numeric',
-      month: 'short',
-      day: '2-digit',
-    }).format(start)
-    const startTime = new Intl.DateTimeFormat('en-AU', {
-      hour: 'numeric',
-      minute: 'numeric',
-      second: 'numeric',
-    }).format(start)
-    const endDate = new Intl.DateTimeFormat('en-AU', {
-      weekday: 'short',
-      year: 'numeric',
-      month: 'short',
-      day: '2-digit',
-    }).format(end)
-    const endTime = new Intl.DateTimeFormat('en-AU', {
-      hour: 'numeric',
-      minute: 'numeric',
-      second: 'numeric',
-    }).format(end)
+    const startDate = formatAsDate(start)
+    const startTime = formatAsTime(start)
+    const endDate = formatAsDate(end)
+    const endTime = formatAsTime(end)
 
     const rangeFormatted =
       startDate === endDate

--- a/openfish-webapp/src/api.types.ts
+++ b/openfish-webapp/src/api.types.ts
@@ -1,3 +1,10 @@
+export type Result<T> = {
+  results: T[]
+  offset: number
+  limit: number
+  total: number
+}
+
 export interface Annotation {
   id: number
   videostreamId: number

--- a/openfish-webapp/src/datetime.ts
+++ b/openfish-webapp/src/datetime.ts
@@ -6,11 +6,58 @@ export function videotimeToDatetime(streamStart: string, time: number): Date {
 }
 
 // Convert a datetime to a video time in seconds.
-export function datetimeToVideoTime(streamStart: string, datetime: string): number {
+export function datetimeToVideoTime(streamStart: DateLike, datetime: DateLike): number {
   return (new Date(datetime).getTime() - new Date(streamStart).getTime()) / 1000
 }
 
 // Subtracts datetimes and returns difference as a number in seconds.
-export function datetimeDifference(a: string, b: string): number {
+export function datetimeDifference(a: DateLike, b: DateLike): number {
   return (new Date(a).getTime() - new Date(b).getTime()) / 1000
+}
+
+// A Date or ISO string representation of a date.
+export type DateLike = Date | string
+
+export function formatAsDate(dt: DateLike): string {
+  return new Intl.DateTimeFormat('en-AU', {
+    weekday: 'short',
+    year: 'numeric',
+    month: 'short',
+    day: '2-digit',
+  }).format(new Date(dt))
+}
+
+export function formatAsTime(dt: DateLike): string {
+  return new Intl.DateTimeFormat('en-AU', {
+    hour: 'numeric',
+    minute: 'numeric',
+    second: 'numeric',
+  }).format(new Date(dt))
+}
+
+export function formatAsDatetime(dt: DateLike): string {
+  return (
+    new Intl.DateTimeFormat('en-AU', {
+      weekday: 'short',
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit',
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+    }).format(new Date(dt)) + ` [${formatAsTimeZone(new Date(dt))}]`
+  )
+}
+
+export function formatAsTimeZone(dt: DateLike): string {
+  return new Intl.DateTimeFormat('en-AU', { day: '2-digit', timeZoneName: 'short' })
+    .format(new Date(dt))
+    .slice(4)
+}
+
+export function formatDuration(duration: number): string {
+  const h = Math.floor(duration / 3600)
+  const m = Math.floor((duration - h * 3600) / 60)
+  const s = duration - h * 3600 - m * 60
+  return `${h}h ${m}m ${s}s `
 }

--- a/openfish-webapp/src/stream-list.ts
+++ b/openfish-webapp/src/stream-list.ts
@@ -1,0 +1,150 @@
+import { LitElement, css, html } from 'lit'
+import { customElement, property } from 'lit/decorators.js'
+import { Result, VideoStream } from './api.types.ts'
+import { repeat } from 'lit/directives/repeat.js'
+import { resetcss } from './reset.css.ts'
+import { datetimeDifference, formatAsDatetime, formatDuration } from './datetime.ts'
+
+@customElement('stream-list')
+export class StreamList extends LitElement {
+  @property({ type: Number })
+  page = 1
+
+  @property({ type: Array })
+  items: VideoStream[] = []
+
+  @property({ type: Number })
+  totalPages = 0
+
+  attributeChangedCallback() {
+    this.fetchData(this.page)
+  }
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.fetchData(this.page)
+  }
+
+  async fetchData(page: number) {
+    const perPage = 10
+
+    try {
+      const res = await fetch(
+        `http://localhost:3000/api/v1/videostreams?limit=10&offset=${(page - 1) * perPage}`
+      )
+      const data = (await res.json()) as Result<VideoStream>
+      this.items = data.results
+      this.totalPages = Math.floor(data.total / perPage)
+      console.log(this.totalPages)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  prev() {
+    this.page += 1
+    this.fetchData(this.page)
+  }
+
+  next() {
+    this.page -= 1
+    this.fetchData(this.page)
+  }
+
+  render() {
+    const header = html`
+    <tr>
+      <th>Stream URL</th>
+      <th>Date & Time</th>
+      <th>Duration</th>
+    </tr>
+    `
+
+    const rows = (stream: VideoStream) => html`
+    <tr onclick="window.location = '/watch.html?id=${stream.id}'">
+      <td>${stream.stream_url}</td>
+      <td>${formatAsDatetime(stream.startTime)}</td>
+      <td>${formatDuration(datetimeDifference(stream.endTime, stream.startTime))}</td>
+    </tr>
+    `
+
+    const pagination = html`   
+    <span class="mr-1">Page ${this.page} of ${this.totalPages}</span>
+    <button @click="${this.next}" .disabled=${this.page === 1}>Prev</button>
+    <button @click="${this.prev}" .disabled=${this.page === this.totalPages}>Next</button>
+    `
+
+    return html`
+    <table>
+    <thead>
+      ${header}
+    </thead>
+    <tbody>
+      ${repeat(this.items, rows)}
+    </tbody>
+    <tfoot>
+      ${pagination}
+    </tfoot>
+    </table>
+    `
+  }
+
+  static styles = css`
+    ${resetcss}
+
+    :host {
+      width: min(100vw, 80rem);
+    }
+
+    table {
+      display: grid;  
+      grid-template-columns: 1fr 20rem 10rem;
+      border-radius: 0.25rem;
+      border: 1px solid var(--gray1);
+    }
+
+    thead, tbody, tr {
+      display: contents;
+    }
+
+    tbody td {
+      padding: 0.5rem 1rem;
+      border-bottom: 1px solid var(--gray1);
+    }
+    tr {
+      cursor: pointer
+    }
+    tr:hover td {
+      background-color: var(--gray0);
+      color: var(--primary)
+    }
+
+    thead th {
+      background-color: var(--gray0);
+      border-bottom: 1px solid var(--gray1);
+      padding: 0.5em 0;
+    }
+
+     tfoot {
+      background-color: var(--gray0);
+      padding: 0.5em 0;
+      grid-column: 1/ span 3;
+      display: flex;
+      justify-content: center;
+      gap: 0.25rem
+    }
+
+    th {
+      padding: 0.5rem
+    }
+    
+    .mr-1 {
+      margin-right: 1rem;
+    }`
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'stream-list': StreamList
+  }
+}

--- a/openfish-webapp/streams.html
+++ b/openfish-webapp/streams.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenFish</title>
+    <link rel="stylesheet" href="./src/index.css" />
+    <script type="module" src="./src/stream-list.ts"></script>
+  </head>
+  <body>
+    <stream-list />
+  </body>
+</html>

--- a/openfish-webapp/vite.config.ts
+++ b/openfish-webapp/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       input: {
         index: resolve(__dirname, 'index.html'),
         watch: resolve(__dirname, 'watch.html'),
+        streams: resolve(__dirname, 'streams.html'),
       },
     },
   },


### PR DESCRIPTION
Closes issue #63 

Adds a list of videostreams user's can browse

Currently, the API is reporting that the total number of videostreams is the same as the limit, this is incorrect which is causing a bug in the user interface - that the next and previous buttons are greyed out. This is a separate issue and will have a separate MR.

Some code from the annotation card file has been refactored out into the datetime.ts file, and is reused here for displaying stream dates in the table

#### Video

[Screencast from 2023-12-01 16-10-17.webm](https://github.com/ausocean/openfish/assets/33645953/eae4bfca-bfaa-4cb9-8134-0a1512f2408e)