### PR TITLE
Register entities so we can use the filestore

### DIFF
--- a/api/ds_client/ds_client.go
+++ b/api/ds_client/ds_client.go
@@ -37,6 +37,7 @@ package ds_client
 import (
 	"context"
 
+	"github.com/ausocean/openfish/api/model"
 	"github.com/ausocean/openfish/datastore"
 )
 
@@ -59,4 +60,8 @@ func Init(local bool) {
 	if err != nil {
 		panic(err)
 	}
+
+	datastore.RegisterEntity(model.CAPTURESOURCE_KIND, model.NewCaptureSource)
+	datastore.RegisterEntity(model.VIDEOSTREAM_KIND, model.NewVideoStream)
+	datastore.RegisterEntity(model.ANNOTATION_KIND, model.NewAnnotation)
 }

--- a/api/model/annotations.go
+++ b/api/model/annotations.go
@@ -100,3 +100,7 @@ func (an *Annotation) Copy(dst datastore.Entity) (datastore.Entity, error) {
 func (an *Annotation) GetCache() datastore.Cache {
 	return nil
 }
+
+func NewAnnotation() datastore.Entity {
+	return &Annotation{}
+}

--- a/api/model/capturesource.go
+++ b/api/model/capturesource.go
@@ -85,3 +85,7 @@ func (cs *CaptureSource) Copy(dst datastore.Entity) (datastore.Entity, error) {
 func (cs *CaptureSource) GetCache() datastore.Cache {
 	return nil
 }
+
+func NewCaptureSource() datastore.Entity {
+	return &CaptureSource{}
+}

--- a/api/model/videostream.go
+++ b/api/model/videostream.go
@@ -86,3 +86,7 @@ func (vs *VideoStream) Copy(dst datastore.Entity) (datastore.Entity, error) {
 func (vs *VideoStream) GetCache() datastore.Cache {
 	return nil
 }
+
+func NewVideoStream() datastore.Entity {
+	return &VideoStream{}
+}


### PR DESCRIPTION
Registers our video stream, annotation and capture source entities so we can use openfish in local mode