### PR TITLE
Refactor API code into services package

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -72,7 +72,7 @@ func registerAPIRoutes(app *fiber.App) {
 	v1.Get("/annotations/:id", handlers.GetAnnotationByID)
 	v1.Get("/annotations", handlers.GetAnnotations)
 	v1.Post("/annotations", handlers.CreateAnnotation)
-
+	v1.Delete("/annotations/:id", handlers.DeleteVideoStream)
 }
 
 // errorHandler creates a HTTP response with the given status code or 500 by default.

--- a/api/model/annotations.go
+++ b/api/model/annotations.go
@@ -61,7 +61,7 @@ type BoundingBox struct {
 
 // An Annotation holds information about observations at a particular moment and region within a video stream.
 type Annotation struct {
-	VideoStreamID    int
+	VideoStreamID    int64
 	TimeSpan         TimeSpan
 	BoundingBox      *BoundingBox // Optional.
 	Observer         string

--- a/api/services/annotations.go
+++ b/api/services/annotations.go
@@ -1,0 +1,178 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package services
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ausocean/openfish/api/ds_client"
+	"github.com/ausocean/openfish/api/model"
+	"github.com/ausocean/openfish/datastore"
+)
+
+// GetAnnotationByID gets an annotation from datastore when provided with an ID.
+func GetAnnotationByID(id int64) (*model.Annotation, error) {
+	store := ds_client.Get()
+	key := store.IDKey(model.ANNOTATION_KIND, id)
+	var annotation model.Annotation
+	err := store.Get(context.Background(), key, &annotation)
+	if err != nil {
+		return nil, err
+	}
+
+	return &annotation, nil
+}
+
+func AnnotationExists(id int64) bool {
+	store := ds_client.Get()
+	key := store.IDKey(model.ANNOTATION_KIND, id)
+	var annotation model.Annotation
+	err := store.Get(context.Background(), key, &annotation)
+	return err == nil
+}
+
+// GetAnnotations gets a list of annotations, filtering by timespan, capturesource, observer & observation if specified.
+func GetAnnotations(limit int, offset int, observer *string, observation map[string]string) ([]model.Annotation, []int64, error) {
+	// Fetch data from the datastore.
+	store := ds_client.Get()
+	query := store.NewQuery(model.ANNOTATION_KIND, false)
+
+	// Filter by observer.
+	if observer != nil {
+		query.FilterField("Observer", "=", *observer)
+	}
+
+	// Filter by observation records.
+	for k, v := range observation {
+		if v == "*" {
+			query.FilterField("ObservationKeys", "=", k)
+		} else {
+			query.FilterField("ObservationPairs", "=", fmt.Sprintf("%s:%s", k, v))
+		}
+	}
+
+	query.Limit(limit)
+	query.Offset(offset)
+
+	var annotations []model.Annotation
+	keys, err := store.GetAll(context.Background(), query, &annotations)
+	if err != nil {
+		return []model.Annotation{}, []int64{}, err
+	}
+	ids := make([]int64, len(annotations))
+	for i, k := range keys {
+		ids[i] = k.ID
+	}
+
+	return annotations, ids, nil
+}
+
+// CreateAnnotation creates a new annotation.
+func CreateAnnotation(videoStreamID int64, timeSpan model.TimeSpan, boundingBox *model.BoundingBox, observer string, observation map[string]string) (int64, error) {
+	// Convert observation map into a format the datastore can take.
+	obsKeys := make([]string, 0, len(observation))
+	obsPairs := make([]string, 0, len(observation))
+
+	for k, v := range observation {
+		obsKeys = append(obsKeys, k)
+		obsPairs = append(obsPairs, fmt.Sprintf("%s:%s", k, v))
+	}
+
+	// Create annotation entity and add to the datastore.
+	an := model.Annotation{
+		VideoStreamID:    videoStreamID,
+		TimeSpan:         timeSpan,
+		BoundingBox:      boundingBox,
+		Observer:         observer,
+		ObservationPairs: obsPairs,
+		ObservationKeys:  obsKeys,
+	}
+
+	// Verify VideoStream exists.
+	if !VideoStreamExists(int64(videoStreamID)) {
+		return 0, errors.New("VideoStream does not exist")
+	}
+
+	// Get a unique ID for the new annotation.
+	store := ds_client.Get()
+	key := store.IncompleteKey(model.ANNOTATION_KIND)
+	key, err := store.Put(context.Background(), key, &an)
+	if err != nil {
+		return 0, err
+	}
+
+	// Return ID of created video stream.
+	return key.ID, nil
+}
+
+// UpdateAnnotation updates an Annotation.
+func UpdateAnnotation(id int64, streamURL *string, captureSource *int64, startTime *time.Time, endTime *time.Time) error {
+
+	// Update data in the datastore.
+	store := ds_client.Get()
+	key := store.IDKey(model.VIDEOSTREAM_KIND, id)
+	var videoStream model.VideoStream
+
+	return store.Update(context.Background(), key, func(e datastore.Entity) {
+		v, ok := e.(*model.VideoStream)
+		if ok {
+			if streamURL != nil {
+				v.StreamUrl = *streamURL
+			}
+			if captureSource != nil {
+				// TODO: Check that captureSource exists.
+				v.CaptureSource = *captureSource
+			}
+			if startTime != nil {
+				v.StartTime = *startTime
+			}
+			if endTime != nil {
+				v.EndTime = endTime
+			}
+		}
+	}, &videoStream)
+}
+
+// DeleteAnnotation deletes an annotation.
+func DeleteAnnotation(id int64) error {
+	// TODO: Check that annotation exists.
+
+	// Delete entity.
+	store := ds_client.Get()
+	key := store.IDKey(model.ANNOTATION_KIND, id)
+	return store.Delete(context.Background(), key)
+}

--- a/api/services/capturesources.go
+++ b/api/services/capturesources.go
@@ -1,0 +1,152 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package services
+
+import (
+	"context"
+
+	googlestore "cloud.google.com/go/datastore"
+
+	"github.com/ausocean/openfish/api/ds_client"
+	"github.com/ausocean/openfish/api/model"
+	"github.com/ausocean/openfish/datastore"
+)
+
+// GetCaptureSourceByID gets a capture source when provided with an ID.
+func GetCaptureSourceByID(id int64) (*model.CaptureSource, error) {
+	store := ds_client.Get()
+	key := store.IDKey(model.CAPTURESOURCE_KIND, id)
+	var captureSource model.CaptureSource
+	err := store.Get(context.Background(), key, &captureSource)
+	if err != nil {
+		return nil, err
+	}
+	return &captureSource, nil
+}
+
+func CaptureSourceExists(id int64) bool {
+	store := ds_client.Get()
+	key := store.IDKey(model.CAPTURESOURCE_KIND, id)
+	var captureSource model.CaptureSource
+	err := store.Get(context.Background(), key, &captureSource)
+	return err == nil
+}
+
+// GetCaptureSources gets a list of capture sources, filtering by name, location if specified.
+func GetCaptureSources(limit int, offset int, name *string) ([]model.CaptureSource, []int64, error) {
+	// Fetch data from the datastore.
+	store := ds_client.Get()
+	query := store.NewQuery(model.CAPTURESOURCE_KIND, false)
+
+	if name != nil {
+		query.FilterField("Name", "=", name)
+	}
+
+	// TODO: implement filtering based on location
+
+	query.Limit(limit)
+	query.Offset(offset)
+
+	var captureSources []model.CaptureSource
+	keys, err := store.GetAll(context.Background(), query, &captureSources)
+	if err != nil {
+		return []model.CaptureSource{}, []int64{}, err
+	}
+	ids := make([]int64, len(captureSources))
+	for i, k := range keys {
+		ids[i] = k.ID
+	}
+
+	return captureSources, ids, nil
+}
+
+// CreateCaptureSource creates a new capture source.
+func CreateCaptureSource(name string, lat float64, long float64, cameraHardware string, siteID *int64) (int64, error) {
+
+	// Get a unique ID for the new capturesource.
+	store := ds_client.Get()
+	key := store.IncompleteKey(model.CAPTURESOURCE_KIND)
+
+	cs := model.CaptureSource{
+		Name:           name,
+		Location:       googlestore.GeoPoint{Lat: lat, Lng: long},
+		CameraHardware: cameraHardware,
+		SiteID:         siteID,
+	}
+
+	// Add to datastore.
+	key, err := store.Put(context.Background(), key, &cs)
+	if err != nil {
+		return 0, err
+	}
+	return key.ID, nil
+}
+
+// UpdateCaptureSource updates a capture source.
+func UpdateCaptureSource(id int64, name *string, lat *float64, long *float64, cameraHardware *string, siteID *int64) error {
+	// TODO: Check that capture source has no video streams associated with it.
+
+	// Update data in the datastore.
+	store := ds_client.Get()
+	key := store.IDKey(model.CAPTURESOURCE_KIND, id)
+	var captureSource model.CaptureSource
+
+	return store.Update(context.Background(), key, func(e datastore.Entity) {
+		v, ok := e.(*model.CaptureSource)
+		if ok {
+			if name != nil {
+				v.Name = *name
+			}
+			if lat != nil && long != nil {
+				v.Location = googlestore.GeoPoint{Lat: *lat, Lng: *long}
+			}
+			if cameraHardware != nil {
+				v.CameraHardware = *cameraHardware
+			}
+			if siteID != nil {
+				v.SiteID = siteID
+			}
+		}
+	}, &captureSource)
+}
+
+// DeleteCaptureSource deletes a capture source.
+func DeleteCaptureSource(id int64) error {
+	// TODO: Check that capture source has no video streams associated with it.
+
+	// Delete entity.
+	store := ds_client.Get()
+	key := store.IDKey(model.CAPTURESOURCE_KIND, id)
+	return store.Delete(context.Background(), key)
+}

--- a/api/services/videostream.go
+++ b/api/services/videostream.go
@@ -1,0 +1,166 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package services
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ausocean/openfish/api/ds_client"
+	"github.com/ausocean/openfish/api/model"
+	"github.com/ausocean/openfish/datastore"
+)
+
+// GetVideoStreamByID gets a video stream when provided with an ID.
+func GetVideoStreamByID(id int64) (*model.VideoStream, error) {
+	store := ds_client.Get()
+	key := store.IDKey(model.VIDEOSTREAM_KIND, id)
+	var videoStream model.VideoStream
+	err := store.Get(context.Background(), key, &videoStream)
+	if err != nil {
+		return nil, err
+	}
+
+	return &videoStream, nil
+}
+
+func VideoStreamExists(id int64) bool {
+	store := ds_client.Get()
+	key := store.IDKey(model.VIDEOSTREAM_KIND, id)
+	var videoStream model.VideoStream
+	err := store.Get(context.Background(), key, &videoStream)
+	return err == nil
+}
+
+// GetVideoStreams gets a list of video streams, filtering by timespan, capturesource if specified.
+func GetVideoStreams(limit int, offset int, timespan *model.TimeSpan, captureSource *int64) ([]model.VideoStream, []int64, error) {
+	// Fetch data from the datastore.
+	store := ds_client.Get()
+	query := store.NewQuery(model.VIDEOSTREAM_KIND, false)
+
+	if captureSource != nil {
+		query.FilterField("CaptureSource", "=", captureSource)
+	}
+
+	if timespan != nil {
+		// BUG: Because of a limitation of google cloud's datastore, we can only use inequality filters on one
+		// field at a time. This query needs to filter out videostreams that started after the specified range.
+		// https://github.com/ausocean/openfish/issues/23
+		query.FilterField("EndTime", ">=", timespan.Start)
+	}
+
+	// TODO: implement filtering based on location
+
+	query.Limit(limit)
+	query.Offset(offset)
+
+	var videoStreams []model.VideoStream
+	keys, err := store.GetAll(context.Background(), query, &videoStreams)
+	if err != nil {
+		return []model.VideoStream{}, []int64{}, err
+	}
+	ids := make([]int64, len(videoStreams))
+	for i, k := range keys {
+		ids[i] = k.ID
+	}
+
+	return videoStreams, ids, nil
+}
+
+// CreateVideoStream puts a video stream in the datastore, checking if the capture source exists.
+func CreateVideoStream(streamURL string, captureSource int64, startTime time.Time, endTime *time.Time) (int64, error) {
+
+	// Verify CaptureSource exists.
+	if !CaptureSourceExists(captureSource) {
+		return 0, fmt.Errorf("CaptureSource does not exist")
+	}
+
+	// Create VideoStream entity.
+	store := ds_client.Get()
+	key := store.IncompleteKey(model.VIDEOSTREAM_KIND)
+
+	vs := model.VideoStream{
+		StreamUrl:     streamURL,
+		CaptureSource: captureSource,
+		StartTime:     startTime,
+		EndTime:       endTime,
+	}
+	key, err := store.Put(context.Background(), key, &vs)
+	if err != nil {
+		return 0, err
+	}
+
+	// Return ID of created video stream.
+	return key.ID, nil
+}
+
+// UpdateCaptureSource updates a capture source.
+func UpdateVideoStream(id int64, streamURL *string, captureSource *int64, startTime *time.Time, endTime *time.Time) error {
+
+	// Update data in the datastore.
+	store := ds_client.Get()
+	key := store.IDKey(model.VIDEOSTREAM_KIND, id)
+	var videoStream model.VideoStream
+
+	return store.Update(context.Background(), key, func(e datastore.Entity) {
+		v, ok := e.(*model.VideoStream)
+		if ok {
+			if streamURL != nil {
+				v.StreamUrl = *streamURL
+			}
+			if captureSource != nil {
+				// TODO: Check that captureSource exists.
+				v.CaptureSource = *captureSource
+			}
+			if startTime != nil {
+				v.StartTime = *startTime
+			}
+			if endTime != nil {
+				v.EndTime = endTime
+			}
+		}
+	}, &videoStream)
+}
+
+// DeleteCaptureSource deletes a capture source.
+func DeleteVideoStream(id int64) error {
+	// TODO: Check that video stream has no annotations associated with it.
+	// TODO: Check that video stream exists.
+
+	// Delete entity.
+	store := ds_client.Get()
+	key := store.IDKey(model.VIDEOSTREAM_KIND, id)
+	return store.Delete(context.Background(), key)
+}


### PR DESCRIPTION
Handlers are now only responsible for the handling of the HTTP request and response. Reading and writing to the datastore, and other logic for ensuring we don't have videostreams pointing to non-existent capture sources etc, has been moved into services. This will make code easier to understand, and make unit testing easier.