### PR TITLE
Improve layout of streams.html page

### DIFF
--- a/openfish-webapp/package.json
+++ b/openfish-webapp/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@fooloomanzoo/datetime-picker": "^3.0.9",
     "lit": "^3.1.0",
     "youtube-player": "^5.6.0"
   },

--- a/openfish-webapp/pnpm-lock.yaml
+++ b/openfish-webapp/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@fooloomanzoo/datetime-picker':
+    specifier: ^3.0.9
+    version: 3.0.9
   lit:
     specifier: ^3.1.0
     version: 3.1.0
@@ -297,6 +300,46 @@ packages:
     dev: true
     optional: true
 
+  /@fooloomanzoo/datetime-input@3.0.4:
+    resolution: {integrity: sha512-oBUMvte2vRVgVjQMHdBl2ieeD32T6VhEXj77s66LFpvAz4nX44PgDUIi3MJmzaBvzXliqml57KKTW7WhgFc28w==}
+    dependencies:
+      '@fooloomanzoo/input-picker-pattern': 3.0.10
+      '@fooloomanzoo/number-input': 3.0.10
+      '@fooloomanzoo/property-mixins': 3.0.10
+      '@polymer/polymer': 3.5.1
+    dev: false
+
+  /@fooloomanzoo/datetime-picker@3.0.9:
+    resolution: {integrity: sha512-4VfrNQCQOFjeOb7UuG06k2om17FMYfm12lFBhCHkHlNnjgafXwrz3ygx4aSFpWCZSz91VR2aIYBYaczU9HkSdA==}
+    dependencies:
+      '@fooloomanzoo/datetime-input': 3.0.4
+      '@fooloomanzoo/input-picker-pattern': 3.0.10
+      '@fooloomanzoo/number-input': 3.0.10
+      '@fooloomanzoo/property-mixins': 3.0.10
+      '@polymer/polymer': 3.5.1
+    dev: false
+
+  /@fooloomanzoo/input-picker-pattern@3.0.10:
+    resolution: {integrity: sha512-jEzJNEXoPsuSTZ51euxJHCfs95v4fX3tl+KCZD81xLVlJXHhfMK40iaUoY2+pE02+m54aQuFH8hxL7c6QQvjSA==}
+    dependencies:
+      '@polymer/iron-overlay-behavior': 3.0.3
+      '@polymer/polymer': 3.5.1
+    dev: false
+
+  /@fooloomanzoo/number-input@3.0.10:
+    resolution: {integrity: sha512-Da5ONp6q4TiksMI2mJ6fsnoDNlghL7uag22Pcd8VJq8NOuLZ0BepGV6DQsCwcjmPJbX2yh5BFuwc+08HYi+nFA==}
+    dependencies:
+      '@fooloomanzoo/input-picker-pattern': 3.0.10
+      '@fooloomanzoo/property-mixins': 3.0.10
+      '@polymer/polymer': 3.5.1
+    dev: false
+
+  /@fooloomanzoo/property-mixins@3.0.10:
+    resolution: {integrity: sha512-V6mO7u0Nzbbgj8eu2U7ReEeuzxO9YgE9VAR4khO7lqCu8+nbiOagv5rSmkMxqVjAfZR1XRt19lEZ7zOx2wrasQ==}
+    dependencies:
+      '@polymer/polymer': 3.5.1
+    dev: false
+
   /@jest/schemas@29.6.3:
     resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -316,6 +359,39 @@ packages:
     resolution: {integrity: sha512-SVOwLAWUQg3Ji1egtOt1UiFe4zdDpnWHyc5qctSceJ5XIu0Uc76YmGpIjZgx9YJ0XtdW0Jm507sDvjOu+HnB8w==}
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.1.2
+    dev: false
+
+  /@polymer/iron-a11y-keys-behavior@3.0.1:
+    resolution: {integrity: sha512-lnrjKq3ysbBPT/74l0Fj0U9H9C35Tpw2C/tpJ8a+5g8Y3YJs1WSZYnEl1yOkw6sEyaxOq/1DkzH0+60gGu5/PQ==}
+    dependencies:
+      '@polymer/polymer': 3.5.1
+    dev: false
+
+  /@polymer/iron-fit-behavior@3.1.0:
+    resolution: {integrity: sha512-ABcgIYqrjhmUT8tiuolqeGttF/8pd3sEymUDrO1vXbZu4FWIvoLNndrMDFvs++AGd12Mjf5pYy84NJc6dB8Vig==}
+    dependencies:
+      '@polymer/polymer': 3.5.1
+    dev: false
+
+  /@polymer/iron-overlay-behavior@3.0.3:
+    resolution: {integrity: sha512-Q/Fp0+uOQQ145ebZ7T8Cxl4m1tUKYjyymkjcL2rXUm+aDQGb1wA1M1LYxUF5YBqd+9lipE0PTIiYwA2ZL/sznA==}
+    dependencies:
+      '@polymer/iron-a11y-keys-behavior': 3.0.1
+      '@polymer/iron-fit-behavior': 3.1.0
+      '@polymer/iron-resizable-behavior': 3.0.1
+      '@polymer/polymer': 3.5.1
+    dev: false
+
+  /@polymer/iron-resizable-behavior@3.0.1:
+    resolution: {integrity: sha512-FyHxRxFspVoRaeZSWpT3y0C9awomb4tXXolIJcZ7RvXhMP632V5lez+ch5G5SwK0LpnAPkg35eB0LPMFv+YMMQ==}
+    dependencies:
+      '@polymer/polymer': 3.5.1
+    dev: false
+
+  /@polymer/polymer@3.5.1:
+    resolution: {integrity: sha512-JlAHuy+1qIC6hL1ojEUfIVD58fzTpJAoCxFwV5yr0mYTXV1H8bz5zy0+rC963Cgr9iNXQ4T9ncSjC2fkF9BQfw==}
+    dependencies:
+      '@webcomponents/shadycss': 1.11.2
     dev: false
 
   /@rollup/rollup-android-arm-eabi@4.5.0:
@@ -463,6 +539,10 @@ packages:
       loupe: 2.3.7
       pretty-format: 29.7.0
     dev: true
+
+  /@webcomponents/shadycss@1.11.2:
+    resolution: {integrity: sha512-vRq+GniJAYSBmTRnhCYPAPq6THYqovJ/gzGThWbgEZUQaBccndGTi1hdiUP15HzEco0I6t4RCtXyX0rsSmwgPw==}
+    dev: false
 
   /acorn-walk@8.3.0:
     resolution: {integrity: sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==}

--- a/openfish-webapp/src/annotation-card.ts
+++ b/openfish-webapp/src/annotation-card.ts
@@ -87,7 +87,7 @@ export class AnnotationCard extends LitElement {
   static styles = css`
   .card {
     background-color: var(--gray0);
-    border: 1px solid var(--gray2);
+    border: 1px solid var(--gray3);
     padding: 1rem;
     border-radius: .5rem;
     box-shadow:  0 0.25rem 0.25rem -0.25rem #00000040;
@@ -102,7 +102,7 @@ export class AnnotationCard extends LitElement {
     justify-content: space-between;
     align-items: baseline;
     width: 100%;
-    border-bottom: 1px solid var(--gray1);
+    border-bottom: 1px solid var(--gray2);
     padding-bottom: 0.5rem;
   }
 
@@ -119,7 +119,7 @@ export class AnnotationCard extends LitElement {
   }
 
   .observer {
-    background-color: var(--gray1);
+    background-color: var(--gray2);
     font-size: 0.8rem;
     padding: 0.125rem 0.75rem;
     border-radius: 0.5rem;
@@ -129,7 +129,7 @@ export class AnnotationCard extends LitElement {
     padding: 0.5rem 0;
     width: 100%;
     font-size: 0.8rem;
-    color: var(--gray3);
+    color: var(--gray5);
   }
   .timestamps>div>:nth-child(1) {
     display: inline-block;
@@ -149,7 +149,7 @@ export class AnnotationCard extends LitElement {
   }
   table th {
     text-align: left;
-    border-bottom: 1px solid var(--gray1);
+    border-bottom: 1px solid var(--gray2);
   }
   table th, table td {
     padding: 0.25rem;

--- a/openfish-webapp/src/api.types.ts
+++ b/openfish-webapp/src/api.types.ts
@@ -37,3 +37,11 @@ export interface VideoStream {
   startTime: string
   endTime: string
 }
+
+export interface CaptureSource {
+  id: number
+  name: string
+  location: `${number},${number}`
+  camera_hardware: string
+  site_id?: number
+}

--- a/openfish-webapp/src/capture-source-dropdown.ts
+++ b/openfish-webapp/src/capture-source-dropdown.ts
@@ -1,0 +1,60 @@
+import { LitElement, css, html } from 'lit'
+import { customElement, state } from 'lit/decorators.js'
+import { Result, CaptureSource } from './api.types.ts'
+import { repeat } from 'lit/directives/repeat.js'
+
+export type SelectCaptureSourceEvent = CustomEvent<number | null>
+
+@customElement('capture-source-dropdown')
+export class CaptureSourceDropdown extends LitElement {
+  @state()
+  _items: CaptureSource[] = []
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.fetchData()
+  }
+
+  async fetchData() {
+    try {
+      const res = await fetch('http://localhost:3000/api/v1/capturesources?limit=999')
+      const data = (await res.json()) as Result<CaptureSource>
+      this._items = data.results
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  onSelectCaptureSource(event: InputEvent & { target: HTMLSelectElement }) {
+    const options = {
+      detail: event.target.value === 'null' ? null : Number(event.target.value),
+      bubbles: true,
+      composed: true,
+    }
+    this.dispatchEvent(new CustomEvent('selectcapturesource', options))
+  }
+
+  render() {
+    return html`
+    <select @input=${this.onSelectCaptureSource}>
+    <option .value=${null}>Any</option>
+    ${repeat(
+      this._items,
+      (item: CaptureSource) => html`<option .value=${item.id}>${item.name}</option>`
+    )}
+    </select>
+    `
+  }
+
+  static styles = css`
+    select {
+      width: 100%;
+    }
+  `
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'capture-source-dropdown': CaptureSourceDropdown
+  }
+}

--- a/openfish-webapp/src/index.css
+++ b/openfish-webapp/src/index.css
@@ -2,11 +2,13 @@
   /* CSS variables */
   --bg: #ffffff;
   --content: #1E293B;
-  --gray0: #f0f0f0;
-  --gray1: #e0e0e0;
-  --gray2: #a4aaae;
-  --gray3: #616265;
 
+  --gray0: #f6f6f7;
+  --gray1: #eff0f3;
+  --gray2: #e2e2e3;
+  --gray3: #c2c2c4;
+  --gray4: #a4aaae;
+  --gray5: #616265;
 
   --primary: #103f79;
   --secondary: #3f9fff; /*#0CA5E9;*/
@@ -58,8 +60,31 @@ a:hover {
 
 /* Page layout */
 body {
-  display: flex; 
-  justify-content: center;
   width: 100vw;
   height: 100vh;
+}
+
+body.grid-layout {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: [fullwidth-start] 1fr [page-start left-aside-start] 16rem [content-start left-aside-end] minmax(auto, 50rem) [content-end right-aside-start] 16rem [page-end right-aside-end] 1fr [fullwidth-end];
+  grid-template-rows: [header-start] 4rem [header-end content-start] 1fr [content-end];
+}
+
+header {
+  grid-column: fullwidth;
+  grid-row-start: 1;
+  grid-row-end: 2;
+  border-bottom: 1px solid var(--gray2);
+  display: grid;
+  grid-template-columns: subgrid;
+  padding: 1rem 0;
+}
+
+header > h1 {
+  grid-column-start: page-start;
+  grid-column-end: content-start;
+  font-size: 1.25rem;
+  font-weight: 600;
+  align-self: end;
 }

--- a/openfish-webapp/src/stream-filter.ts
+++ b/openfish-webapp/src/stream-filter.ts
@@ -1,0 +1,128 @@
+import { LitElement, css, html } from 'lit'
+import { customElement, state } from 'lit/decorators.js'
+import { resetcss } from './reset.css.ts'
+import '@fooloomanzoo/datetime-picker/datetime-picker.js'
+import { type SelectCaptureSourceEvent } from './capture-source-dropdown.ts'
+
+// TODO: add support for start and end times.
+export type Filter = {
+  captureSource?: number
+  'timespan[start]'?: string
+  'timespan[end]'?: string
+}
+
+export type FilterUpdateEvent = CustomEvent<Filter>
+
+@customElement('stream-filter')
+export class StreamFilter extends LitElement {
+  @state()
+  protected _captureSource: number | null = null
+
+  @state()
+  protected _startTime: string | undefined
+
+  @state()
+  protected _endTime: string | undefined
+
+  dispatchFilterUpdateEvent() {
+    const detail: Filter = {}
+    if (this._captureSource !== null) {
+      detail.captureSource = this._captureSource
+    }
+
+    if (this._startTime != null) {
+      detail['timespan[start]'] = this._startTime
+    }
+    if (this._endTime != null) {
+      detail['timespan[end]'] = this._endTime
+    }
+
+    const options = {
+      detail: detail,
+      bubbles: true,
+      composed: true,
+    }
+    this.dispatchEvent(new CustomEvent('filterupdate', options))
+  }
+
+  onSelectCaptureSource(event: SelectCaptureSourceEvent) {
+    this._captureSource = event.detail
+    this.dispatchFilterUpdateEvent()
+  }
+
+  onCloseStartDatetime(event: CustomEvent) {
+    this._startTime = event.detail.datetime
+    this.dispatchFilterUpdateEvent()
+  }
+
+  onCloseEndDatetime(event: CustomEvent) {
+    this._endTime = event.detail.datetime
+    this.dispatchFilterUpdateEvent()
+  }
+
+  render() {
+    return html`
+    <aside>
+        <h3>Filter Options</h3>
+        <form>
+            <fieldset>
+            <legend>Filter by time of stream</legend>
+            <label>From:</label>
+            <datetime-picker locale="en-AU" @input-picker-closed=${this.onCloseStartDatetime}></datetime-picker>
+
+            <label>Until:</label>
+            <datetime-picker locale="en-AU" @input-picker-closed=${this.onCloseEndDatetime}></datetime-picker>
+            </fieldset>
+
+            <fieldset>
+            <legend>Filter by capture source</legend>
+            <label>Capture source:</label>
+            <capture-source-dropdown @selectcapturesource=${this.onSelectCaptureSource}></capture-source-dropdown>
+            </fieldset>
+        </form>
+    </aside>
+    `
+  }
+
+  static styles = css`
+    ${resetcss}
+    aside {
+      background-color: var(--gray0);
+      border-radius: 0.25rem;
+      border: 1px solid var(--gray2);
+    }
+
+    h3 {
+        margin-top: 0;
+        margin-bottom: 0;
+        padding: .5rem 1.5rem; 
+        background-color: var(--gray0);
+        border-bottom: 1px solid var(--gray2);
+    }
+
+    form {
+        padding: .5rem .5rem; 
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+    }
+
+    datetime-picker {
+        margin-top: .25rem;
+    }
+
+    capture-source-dropdown {
+        width: 100%;
+    }
+
+    fieldset {
+        border-radius: 0.25rem;
+    }
+    `
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'stream-filter': StreamFilter
+  }
+}

--- a/openfish-webapp/streams.html
+++ b/openfish-webapp/streams.html
@@ -6,9 +6,41 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenFish</title>
     <link rel="stylesheet" href="./src/index.css" />
+
     <script type="module" src="./src/stream-list.ts"></script>
+    <script type="module" src="./src/stream-filter.ts"></script>
+    <script type="module" src="./src/capture-source-dropdown.ts"></script>
+
+    <style>
+      stream-filter {
+        grid-row: content;
+        grid-column: left-aside;
+        height: min-content;
+      }
+      stream-list {
+        grid-row: content;
+        grid-column-start: content-start;
+        grid-column-end: page-end;
+      }
+    </style>
+
+    <script type="module">
+      window.onload = () => {
+        const streamFilter = document.querySelector('stream-filter')
+        const streamList = document.querySelector('stream-list')
+
+        streamFilter?.addEventListener('filterupdate', (event) => {
+          streamList.filter = event.detail
+          streamList.requestUpdate()
+        })
+      }
+    </script>
   </head>
-  <body>
-    <stream-list />
+  <body class="grid-layout">
+    <header>
+      <h1>OpenFish WebApp</h1>
+    </header>
+    <stream-filter></stream-filter>
+    <stream-list></stream-list>
   </body>
 </html>


### PR DESCRIPTION
Improves on the layout of the streams.html page. Adds a menu sidebar for filtering streams. Refactors some code to use `@state` instead of `@property` where appropriate. 

### Screenshot
![image](https://github.com/ausocean/openfish/assets/33645953/10c3e9e1-68a7-4433-a8c2-e9b1c2db6246)

### Layout
The layout uses css grid with named dividers - this is what the grid regions look like with dev tools enabled
![image](https://github.com/ausocean/openfish/assets/33645953/b635d842-1bde-449a-abeb-496a40c3b3e3)

## Dependencies
This PR adds another dependency: `@fooloomanzoo/datetime-picker` - it is used for the date picker. It is a webcomponent/custom element. 

![image](https://github.com/ausocean/openfish/assets/33645953/572b5a69-d9cb-4767-a3b5-24f16ab0f817)



