### PR TITLE
Refactor out annotation-overlay as component

### DIFF
--- a/openfish-webapp/src/annotation-overlay.ts
+++ b/openfish-webapp/src/annotation-overlay.ts
@@ -1,28 +1,18 @@
 import { LitElement, css, html, svg } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
-import { Annotation, VideoStream } from './api.types.ts'
+import { Annotation } from './api.types.ts'
 import { repeat } from 'lit/directives/repeat.js'
 import { resetcss } from './reset.css.ts'
 
-@customElement('video-player')
-export class VideoPlayer extends LitElement {
+export type MouseoverAnnotationEvent = CustomEvent<number | null>
+
+@customElement('annotation-overlay')
+export class AnnotationOverlay extends LitElement {
   @property({ type: Array })
   annotations: Annotation[] = []
 
   @property({ type: Number })
   activeAnnotation: number | null = null
-
-  @property({ type: Object })
-  videostream: VideoStream | null = null
-
-  @property({ type: Number })
-  currentTime = 0
-
-  @property({ type: Boolean })
-  playing = false
-
-  @property({ type: Number })
-  seekTo: number | null = null
 
   hoverAnnotation(id: number | null) {
     this.dispatchEvent(new CustomEvent('mouseover-annotation', { detail: id }))
@@ -52,62 +42,17 @@ export class VideoPlayer extends LitElement {
         </g>`
     })
 
-    let video = html``
-    if (this.videostream?.stream_url != null) {
-      video = html`
-        <youtube-player 
-          id="yt" 
-          .url=${this.videostream.stream_url} 
-          .playing=${this.playing}
-          .seekTo=${this.seekTo}
-          @timeupdate=${(e: CustomEvent) => {
-            this.currentTime = e.detail
-            this.seekTo = null
-            this.dispatchEvent(new CustomEvent('timeupdate', { detail: e.detail }))
-          }}
-          @durationchange=${(e: CustomEvent) => {
-            this.dispatchEvent(new CustomEvent('durationchange', { detail: e.detail }))
-          }}
-          @loadeddata=${() => this.dispatchEvent(new Event('loadeddata'))}
-        />`
-    }
-
     return html`
-      <div class="video-container">
-        ${video}
-        <div class="annotation-overlay">
           <svg width="100%" height="100%">
             ${rects}
-          </svg>
-        </div>
-      </div>`
+          </svg>`
   }
 
   static styles = css`
     ${resetcss}
 
-    .no-video {
-      font-weight: bold;
-      color: var(--bg);
-    }
-    .video-container {
-      width: 100%;
-      aspect-ratio: 4 / 3;  
-      background-color: var(--gray-300);
-      position: relative
-    }
-    .annotation-overlay {
+    svg {
       pointer-events: none;
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      z-index: 3;
-    }
-    youtube-player {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      z-index: 2;
     }
     .annotation-rect {
       transition: fill 0.25s;
@@ -126,6 +71,6 @@ export class VideoPlayer extends LitElement {
 
 declare global {
   interface HTMLElementTagNameMap {
-    'video-player': VideoPlayer
+    'annotation-overlay': AnnotationOverlay
   }
 }

--- a/openfish-webapp/src/youtube-player.ts
+++ b/openfish-webapp/src/youtube-player.ts
@@ -3,6 +3,10 @@ import { customElement, property } from 'lit/decorators.js'
 import useYoutubePlayer from 'youtube-player'
 import type { YouTubePlayer } from 'youtube-player/dist/types'
 
+export type TimeUpdateEvent = CustomEvent<number>
+export type DurationChangeEvent = CustomEvent<number>
+export type LoadedEvent = Event
+
 @customElement('youtube-player')
 export class YouTubePlayerElement extends LitElement {
   @property({ type: String })

--- a/openfish-webapp/watch.html
+++ b/openfish-webapp/watch.html
@@ -7,10 +7,6 @@
     <title>OpenFish | Watch</title>
     <link rel="stylesheet" href="./src/index.css" />
     <script type="module" src="/src/watch-stream.ts"></script>
-    <script type="module" src="/src/annotation-card.ts"></script>
-    <script type="module" src="/src/video-player.ts"></script>
-    <script type="module" src="/src/playback-controls.ts"></script>
-    <script type="module" src="/src/youtube-player.ts"></script>
 
     <style>
       main {


### PR DESCRIPTION
Part of issue #65 

This refactors out annotation-overlay as a component in preparation for adding support to create annotations. 

This is required because as a separate component, annotation-overlay can be hidden from the page when a user is creating a new annotation and a different (yet to be created component) can be shown to let the user draw the bounding box

Cannot be merged until PR #85  is merged