### PR TITLE
Deploy to appengine

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,18 @@
+# Only include what we specify
+*
+
+# Configuration files.
+!app.yaml
+
+# Go code.
+!go.mod
+!go.sum
+!api/
+!datastore/
+
+
+# Vite output directory.
+# Include only openfish-webapp/dist, but nothing else from openfish-webapp.
+!openfish-webapp
+openfish-webapp/*
+!openfish-webapp/dist

--- a/api/ds_client/ds_client.go
+++ b/api/ds_client/ds_client.go
@@ -55,7 +55,7 @@ func Init(local bool) {
 	if local {
 		store, err = datastore.NewStore(ctx, "file", "openfish", "./store")
 	} else {
-		store, err = datastore.NewStore(ctx, "cloud", "openfish-dev", "")
+		store, err = datastore.NewStore(ctx, "cloud", "openfish", "")
 	}
 	if err != nil {
 		panic(err)

--- a/api/main.go
+++ b/api/main.go
@@ -109,5 +109,5 @@ func main() {
 		AllowOrigins: "*",
 	}))
 	registerAPIRoutes(app)
-	app.Listen(":3000")
+	app.Listen(":8080")
 }

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,22 @@
+runtime: go120
+
+env_variables:
+  OPENFISH_CREDENTIALS: gs://ausocean/OpenFish-a197b0443246.json
+
+main: ./api/main.go
+
+handlers:
+
+  - url: /api/.*
+    script: auto
+  
+  # Serve index.html as /
+  - url: /
+    static_files: openfish-webapp/dist/index.html  
+    upload: openfish-webapp/dist/index.html
+
+  # TODO: Serve watch.html and streams.html from /watch and /streams urls.
+  
+  # Serve all files in dist.
+  - url: /
+    static_dir: openfish-webapp/dist

--- a/docker/api
+++ b/docker/api
@@ -12,5 +12,5 @@ RUN go build -o ./openfish-api ./api
 FROM alpine:3.14 as production-stage
 WORKDIR /app
 COPY --from=build-stage /src/openfish-api ./
-EXPOSE 3000
+EXPOSE 8080
 ENTRYPOINT [ "/app/openfish-api" ] 

--- a/docs/api/video-streams.md
+++ b/docs/api/video-streams.md
@@ -86,7 +86,7 @@ Stream 5: | •---•   :              :
 ## Creating a video stream
 ::: code-group
 ```http [Request]
-POST http://localhost:3000/api/v1/videostreams
+POST http://localhost:8080/api/v1/videostreams
 Content-Type: application/json
 
 {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -19,7 +19,7 @@ You will need installed:
 
 2) Run both containers:
    ```bash
-   docker run -p 3000:3000 openfish-api          
+   docker run -p 8080:8080 openfish-api          
    docker run -p 80:80 openfish-webapp
    ```
 3) Open the browser and visit http://localhost.

--- a/openfish-webapp/.env
+++ b/openfish-webapp/.env
@@ -1,0 +1,2 @@
+# When testing locally use: http://localhost:3000
+VITE_API_HOST=https://openfish.appspot.com

--- a/openfish-webapp/.env
+++ b/openfish-webapp/.env
@@ -1,2 +1,2 @@
-# When testing locally use: http://localhost:3000
+# When testing locally use: http://localhost:8080
 VITE_API_HOST=https://openfish.appspot.com

--- a/openfish-webapp/src/capture-source-dropdown.ts
+++ b/openfish-webapp/src/capture-source-dropdown.ts
@@ -17,7 +17,7 @@ export class CaptureSourceDropdown extends LitElement {
 
   async fetchData() {
     try {
-      const res = await fetch('http://localhost:3000/api/v1/capturesources?limit=999')
+      const res = await fetch(`${import.meta.env.VITE_API_HOST}/api/v1/capturesources?limit=999`)
       const data = (await res.json()) as Result<CaptureSource>
       this._items = data.results
     } catch (error) {

--- a/openfish-webapp/src/stream-list.ts
+++ b/openfish-webapp/src/stream-list.ts
@@ -43,7 +43,9 @@ export class StreamList extends LitElement {
         params.set(key, String(this._filter[key as keyof Filter]))
       }
 
-      const res = await fetch(`http://localhost:3000/api/v1/videostreams?${params.toString()}`)
+      const res = await fetch(
+        `${import.meta.env.VITE_API_HOST}/api/v1/videostreams?${params.toString()}`
+      )
       const data = (await res.json()) as Result<VideoStream>
       this._items = data.results
       this._totalPages = Math.floor(data.total / perPage)

--- a/openfish-webapp/src/watch-stream.ts
+++ b/openfish-webapp/src/watch-stream.ts
@@ -50,7 +50,7 @@ export class WatchStream extends LitElement {
   async fetchData(id: number) {
     try {
       // Fetch video stream with ID.
-      const res = await fetch(`http://localhost:3000/api/v1/videostreams/${id}`)
+      const res = await fetch(`${import.meta.env.VITE_API_HOST}/api/v1/videostreams/${id}`)
       this._videostream = (await res.json()) as VideoStream
     } catch (error) {
       console.error(error) // TODO: handle errors.
@@ -59,7 +59,9 @@ export class WatchStream extends LitElement {
       // Fetch annotations for this video stream.
       // TODO: We should only fetch a small portion of the annotations near the current playback position.
       //       When the user plays the video we can fetch in more as needed.
-      const res = await fetch(`http://localhost:3000/api/v1/annotations?videostream=${id}`)
+      const res = await fetch(
+        `${import.meta.env.VITE_API_HOST}/api/v1/annotations?videostream=${id}`
+      )
       const json = await res.json()
       this._annotations = json.results as Annotation[]
     } catch (error) {


### PR DESCRIPTION
Openfish can now be deployed to appengine.

See here:
https://openfish.appspot.com/streams.html

Changes:
- app.yaml and .gcloudignore added for deploying to google appengine
- Few changes in /api to make it work when deployed
- Remove hardcoded localhost:3000 from Openfish webapp