### PR TITLE
Fix display of time on playback controls

### DIFF
--- a/openfish-webapp/src/datetime.ts
+++ b/openfish-webapp/src/datetime.ts
@@ -59,3 +59,9 @@ export function formatDuration(duration: number): string {
   const s = duration - h * 3600 - m * 60
   return `${h}h ${m}m ${s}s `
 }
+
+export function formatVideoTime(seconds: number): string {
+  const date = new Date(0)
+  date.setSeconds(seconds)
+  return date.toISOString().substring(11, 19)
+}

--- a/openfish-webapp/src/playback-controls.ts
+++ b/openfish-webapp/src/playback-controls.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html, svg } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import { Annotation, VideoStream } from './api.types'
 import { repeat } from 'lit/directives/repeat.js'
-import { datetimeDifference, datetimeToVideoTime } from './datetime'
+import { datetimeDifference, datetimeToVideoTime, formatVideoTime } from './datetime'
 import { resetcss } from './reset.css'
 
 @customElement('playback-controls')
@@ -87,7 +87,7 @@ export class PlaybackControls extends LitElement {
             @input="${this.seek}" 
           />
         </div>
-        <span>${Math.floor(this.currentTime)} / ${Math.floor(this.duration)}</span>
+        <span>${formatVideoTime(this.currentTime)} / ${formatVideoTime(this.duration)}</span>
       </div>`
   }
 
@@ -112,8 +112,8 @@ export class PlaybackControls extends LitElement {
     span {
       white-space: nowrap;
       padding: 0.25rem;
-      width: 8rem;
-      text-align: center;
+      width: 15rem;
+      text-align: right;
     }
     #rangecontrols {
       height: 2rem;


### PR DESCRIPTION
Currently, we display the number of seconds, which for a many hour stream is a very large number. This changes it to display the number of hours, minutes and seconds

![image](https://github.com/ausocean/openfish/assets/33645953/7e8c044d-668f-4e76-adcf-41873b6a08d3)
