### PR TITLE
Fix youtube player jump to start bug

### DIFF
--- a/openfish-webapp/src/youtube-player.ts
+++ b/openfish-webapp/src/youtube-player.ts
@@ -12,13 +12,8 @@ export class YouTubePlayerElement extends LitElement {
   @property({ type: String })
   url = ''
 
-  private _playing = false
   @property()
-  get playing() {
-    return this._playing
-  }
   set playing(val: boolean) {
-    this._playing = val
     if (val) {
       this._player?.playVideo()
     } else {


### PR DESCRIPTION
There is a bug where clicking pause will jump the video back to the start of playback. This fixes that issue