### PR TITLE
Species guide api

### DIFF
--- a/api/entities/species.go
+++ b/api/entities/species.go
@@ -1,0 +1,91 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package entities
+
+import (
+	"encoding/json"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// Kind of entity to store / fetch from the datastore.
+const SPECIES_KIND = "Species"
+
+// Species is used for our guide.
+type Species struct {
+	Species    string
+	CommonName string
+	Images     []Image
+}
+
+type Image struct {
+	Src         string `json:"src"`
+	Attribution string `json:"attribution"`
+}
+
+// Encode serializes Species. Implements Entity interface. Used for FileStore datastore.
+func (vs *Species) Encode() []byte {
+	bytes, _ := json.Marshal(vs)
+	return bytes
+}
+
+// Encode deserializes Species. Implements Entity interface. Used for FileStore datastore.
+func (vs *Species) Decode(b []byte) error {
+	return json.Unmarshal(b, vs)
+}
+
+// Implements Copy from the Entity interface.
+func (vs *Species) Copy(dst datastore.Entity) (datastore.Entity, error) {
+	var v *Species
+	if dst == nil {
+		v = new(Species)
+	} else {
+		var ok bool
+		v, ok = dst.(*Species)
+		if !ok {
+			return nil, datastore.ErrWrongType
+		}
+	}
+	*v = *vs
+	return v, nil
+}
+
+// No caching is used.
+func (vs *Species) GetCache() datastore.Cache {
+	return nil
+}
+
+func NewSpecies() datastore.Entity {
+	return &Species{}
+}

--- a/api/handlers/species.go
+++ b/api/handlers/species.go
@@ -1,0 +1,186 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// handlers package handles HTTP requests.
+package handlers
+
+import (
+	"strconv"
+
+	"github.com/ausocean/openfish/api/api"
+	"github.com/ausocean/openfish/api/entities"
+	"github.com/ausocean/openfish/api/services"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// SpeciesResult describes the JSON format for species in API responses.
+// Fields use pointers because they are optional (this is what the format URL param is for).
+type SpeciesResult struct {
+	ID         *int64            `json:"id,omitempty"`
+	Species    *string           `json:"species,omitempty"`
+	CommonName *string           `json:"common_name,omitempty"`
+	Images     *[]entities.Image `json:"images,omitempty"`
+}
+
+// FromSpecies creates a SpeciesResult from a entities.Species and key, formatting it according to the requested format.
+func FromSpecies(species *entities.Species, id int64, format *api.Format) SpeciesResult {
+	var result SpeciesResult
+	if format.Requires("id") {
+		result.ID = &id
+	}
+	if format.Requires("species") {
+		result.Species = &species.Species
+	}
+	if format.Requires("common_name") {
+		result.CommonName = &species.CommonName
+	}
+	if format.Requires("images") {
+		result.Images = &species.Images
+	}
+	return result
+}
+
+// GetRecommendedSpeciesQuery describes the URL query parameters required for the GetRecommendedSpecies endpoint.
+type GetRecommendedSpeciesQuery struct {
+	VideoStream   *int64 `query:"videostream"`   // Optional.
+	CaptureSource *int64 `query:"capturesource"` // Optional.
+	api.LimitAndOffset
+}
+
+// CreateSpeciesBody describes the JSON format required for the CreateSpecies endpoint.
+//
+// ID is omitted because it is chosen automatically.
+type CreateSpeciesBody struct {
+	Species    string           `json:"species"`
+	CommonName string           `json:"common_name"`
+	Images     []entities.Image `json:"images"`
+}
+
+// GetSpeciesByID gets a species when provided with an ID.
+func GetSpeciesByID(ctx *fiber.Ctx) error {
+	// Parse URL.
+	format := new(api.Format)
+
+	if err := ctx.QueryParser(format); err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	id, err := strconv.ParseInt(ctx.Params("id"), 10, 64)
+	if err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	// Fetch data from the datastore.
+	species, err := services.GetSpeciesByID(id)
+	if err != nil {
+		return api.DatastoreReadFailure(err)
+	}
+
+	// Format result.
+	result := FromSpecies(species, id, format)
+	return ctx.JSON(result)
+}
+
+// GetRecommendedSpecies gets a list of species, most relevant for the specified stream and capture source.
+func GetRecommendedSpecies(ctx *fiber.Ctx) error {
+	// Parse URL.
+	qry := new(GetRecommendedSpeciesQuery)
+	qry.SetLimit()
+
+	if err := ctx.QueryParser(qry); err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	format := new(api.Format)
+	if err := ctx.QueryParser(format); err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	// Fetch data from the datastore.
+	species, ids, err := services.GetRecommendedSpecies(qry.Limit, qry.Offset, qry.VideoStream, qry.CaptureSource)
+	if err != nil {
+		return api.DatastoreReadFailure(err)
+	}
+
+	// Format results.
+	results := make([]SpeciesResult, len(species))
+	for i := range species {
+		results[i] = FromSpecies(&species[i], int64(ids[i]), format)
+	}
+
+	return ctx.JSON(api.Result[SpeciesResult]{
+		Results: results,
+		Offset:  qry.Offset,
+		Limit:   qry.Limit,
+		Total:   len(results),
+	})
+}
+
+// CreateSpecies creates a new species.
+func CreateSpecies(ctx *fiber.Ctx) error {
+	// Parse body.
+	var body CreateSpeciesBody
+	err := ctx.BodyParser(&body)
+	if err != nil {
+		return api.InvalidRequestJSON(err)
+	}
+
+	// Create video stream entity and add to the datastore.
+	id, err := services.CreateSpecies(body.Species, body.CommonName, body.Images)
+	if err != nil {
+		return api.DatastoreWriteFailure(err)
+	}
+
+	// Return ID of created video stream.
+	return ctx.JSON(VideoStreamResult{
+		ID: &id,
+	})
+}
+
+// DeleteSpecies deletes a species.
+func DeleteSpecies(ctx *fiber.Ctx) error {
+	// Parse URL.
+	id, err := strconv.ParseInt(ctx.Params("id"), 10, 64)
+	if err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	// Delete entity.
+	err = services.DeleteSpecies(id)
+	if err != nil {
+		return api.DatastoreWriteFailure(err)
+	}
+
+	return nil
+}

--- a/api/main.go
+++ b/api/main.go
@@ -72,7 +72,13 @@ func registerAPIRoutes(app *fiber.App) {
 	v1.Get("/annotations/:id", handlers.GetAnnotationByID)
 	v1.Get("/annotations", handlers.GetAnnotations)
 	v1.Post("/annotations", handlers.CreateAnnotation)
-	v1.Delete("/annotations/:id", handlers.DeleteVideoStream)
+	v1.Delete("/annotations/:id", handlers.DeleteAnnotation)
+
+	// Species.
+	v1.Get("/species/recommended", handlers.GetRecommendedSpecies)
+	v1.Get("/species/:id", handlers.GetSpeciesByID)
+	v1.Post("/species", handlers.CreateSpecies)
+	v1.Delete("/species/:id", handlers.DeleteSpecies)
 }
 
 // errorHandler creates a HTTP response with the given status code or 500 by default.

--- a/api/services/capturesource_test.go
+++ b/api/services/capturesource_test.go
@@ -48,6 +48,7 @@ func setup() {
 	_ = os.Mkdir("store/openfish/CaptureSource", os.ModePerm)
 	_ = os.Mkdir("store/openfish/VideoStream", os.ModePerm)
 	_ = os.Mkdir("store/openfish/Annotation", os.ModePerm)
+	_ = os.Mkdir("store/openfish/Species", os.ModePerm)
 
 }
 

--- a/api/services/species.go
+++ b/api/services/species.go
@@ -1,0 +1,115 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package services
+
+import (
+	"context"
+
+	"github.com/ausocean/openfish/api/ds_client"
+	"github.com/ausocean/openfish/api/entities"
+)
+
+// GetSpeciesByID gets a species when provided with an ID.
+func GetSpeciesByID(id int64) (*entities.Species, error) {
+	store := ds_client.Get()
+	key := store.IDKey(entities.SPECIES_KIND, id)
+	var species entities.Species
+	err := store.Get(context.Background(), key, &species)
+	if err != nil {
+		return nil, err
+	}
+
+	return &species, nil
+}
+
+func SpeciesExists(id int64) bool {
+	store := ds_client.Get()
+	key := store.IDKey(entities.SPECIES_KIND, id)
+	var species entities.Species
+	err := store.Get(context.Background(), key, &species)
+	return err == nil
+}
+
+// GetRecommendedSpecies gets a list of species, most relevant for the specified stream and capture source.
+func GetRecommendedSpecies(limit int, offset int, videostream *int64, captureSource *int64) ([]entities.Species, []int64, error) {
+	// Fetch data from the datastore.
+	store := ds_client.Get()
+	query := store.NewQuery(entities.SPECIES_KIND, false)
+
+	// TODO: implement returning most relevant species.
+
+	query.Limit(limit)
+	query.Offset(offset)
+
+	var species []entities.Species
+	keys, err := store.GetAll(context.Background(), query, &species)
+	if err != nil {
+		return []entities.Species{}, []int64{}, err
+	}
+	ids := make([]int64, len(species))
+	for i, k := range keys {
+		ids[i] = k.ID
+	}
+
+	return species, ids, nil
+}
+
+// CreateSpecies puts a species in the datastore.
+func CreateSpecies(species string, commonName string, images []entities.Image) (int64, error) {
+
+	// Create Species entity.
+	store := ds_client.Get()
+	key := store.IncompleteKey(entities.SPECIES_KIND)
+
+	vs := entities.Species{
+		Species:    species,
+		CommonName: commonName,
+		Images:     images,
+	}
+	key, err := store.Put(context.Background(), key, &vs)
+	if err != nil {
+		return 0, err
+	}
+
+	// Return ID of created species.
+	return key.ID, nil
+}
+
+// DeleteSpecies deletes a species.
+func DeleteSpecies(id int64) error {
+	// Delete entity.
+	store := ds_client.Get()
+	key := store.IDKey(entities.SPECIES_KIND, id)
+	return store.Delete(context.Background(), key)
+}

--- a/api/services/species_test.go
+++ b/api/services/species_test.go
@@ -1,0 +1,126 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/ausocean/openfish/api/entities"
+	"github.com/ausocean/openfish/api/services"
+)
+
+func TestCreateSpecies(t *testing.T) {
+	setup()
+
+	// Create a new species entity.
+	_, err := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0))
+	if err != nil {
+		t.Errorf("Could not create species entity %s", err)
+	}
+}
+
+func TestSpeciesExists(t *testing.T) {
+	setup()
+
+	// Create a new species entity.
+	id, _ := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0))
+
+	// Check if the species exists.
+	if !services.SpeciesExists(int64(id)) {
+		t.Errorf("Expected species to exist")
+	}
+}
+
+func TestSpeciesExistsForNonexistentEntity(t *testing.T) {
+	setup()
+
+	// Check if the species exists.
+	// We expect it to return false.
+	if services.SpeciesExists(int64(123456789)) {
+		t.Errorf("Did not expect species to exist")
+	}
+}
+
+func TestGetSpeciesByID(t *testing.T) {
+	setup()
+
+	// Create a new species entity.
+	id, _ := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0))
+
+	species, err := services.GetSpeciesByID(int64(id))
+	if err != nil {
+		t.Errorf("Could not get species entity %s", err)
+	}
+	if species.CommonName != "Southern Reef Squid" && species.Species != "Sepioteuthis australis" && len(species.Images) != 0 {
+		t.Errorf("Video stream entity does not match created entity")
+	}
+}
+
+func TestGetSpeciesByIDForNonexistentEntity(t *testing.T) {
+	setup()
+
+	species, err := services.GetSpeciesByID(int64(123456789))
+	if species != nil && err == nil {
+		t.Errorf("GetSpeciesByID returned non-existing entity %s", err)
+	}
+}
+
+// TODO: Write tests for GetRecommendedSpecies. Test limit, offset, and sorting.
+
+func TestDeleteSpecies(t *testing.T) {
+	setup()
+
+	// Create a new species entity.
+	id, _ := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0))
+
+	// Delete the species entity.
+	err := services.DeleteSpecies(int64(id))
+	if err != nil {
+		t.Errorf("Could not delete species entity %d: %s", id, err)
+	}
+
+	// Check if the species exists.
+	if services.SpeciesExists(int64(id)) {
+		t.Errorf("Video stream entity exists after delete")
+	}
+}
+
+func TestDeleteSpeciesForNonexistentEntity(t *testing.T) {
+	setup()
+
+	err := services.DeleteSpecies(int64(123456789))
+	if err == nil {
+		t.Errorf("Did not receive expected error when deleting non-existent species")
+	}
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -26,6 +26,7 @@ export default defineConfig({
             { text: 'Capture Sources', link: '/api/capture-sources'},
             { text: 'Video Streams', link: '/api/video-streams'},
             { text: 'Annotations', link: '/api/annotations'},
+            { text: 'Species', link: '/api/species'},
           ]},
 
         ]

--- a/docs/api/species.md
+++ b/docs/api/species.md
@@ -1,0 +1,105 @@
+# Species
+**Authors:** Scott Barnard
+
+Species are used for providing suggestions to our users when annotating videos. They store the latin and common name, and an array of images. Images have a source and attribution - we use this to give the author credit and to abide by the rules of the license.
+
+OpenFish provides APIs to create, get and delete species. The `/api/v1/species/recommended` API returns the most relevant species first, depending on the supplied video stream, and capture source.
+
+
+## Fetching the most relevant species
+So OpenFish can provide a list of species most relevant, you should provide the video stream and capture source for context. These are optional, if either is omitted, they will not be used to determine the most relevant species, if both are omitted then the list will be unsorted.
+
+::: code-group
+```http [Request]
+GET /api/v1/species/recommended?videostream=12345&capturesource=67890
+```
+
+```http [Response]
+HTTP/1.1 200
+content-type: application/json
+
+{
+  "results": [
+    {
+      "id": 5701666712059904,
+      "species": "Sepioteuthis australis",
+      "common_name": "Southern Reef Squid",
+      "images": [
+        {
+          "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/340064435/medium.jpg",
+          "attribution": "Tiffany Kosch, CC BY-NC-SA 4.0"
+        }
+      ]
+    }
+  ],
+  "offset": 0,
+  "limit": 20,
+  "total": 1
+}
+```
+:::
+
+## Fetching a single species
+::: code-group
+```http [Request]
+GET /api/v1/species/<species ID>
+```
+
+```http [Response]
+HTTP/1.1 200
+
+{
+  "id": <species ID>,
+  "species": "Sepioteuthis australis",
+  "common_name": "Southern Reef Squid",
+  "images": [
+    {
+      "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/340064435/medium.jpg",
+      "attribution": "Tiffany Kosch, CC BY-NC-SA 4.0"
+    }
+  ]
+}
+```
+:::
+
+
+## Creating species
+Species have a latin and common name, and a list of images. All fields are mandatory.
+::: code-group
+```http [Request]
+POST /api/v1/species
+content-type: application/json
+
+{
+    "species": "Sepioteuthis australis",
+    "common_name": "Southern Reef Squid",
+    "images": [
+        {
+        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/340064435/medium.jpg",
+        "attribution": "Tiffany Kosch, CC BY-NC-SA 4.0"
+        }
+    ]
+}
+```
+
+```http [Response]
+HTTP/1.1 200
+
+{
+  "id": <species ID>
+}
+```
+:::
+
+## Deleting a species
+Successful delete will return 200 OK.
+
+::: code-group
+```http [Request]
+DELETE /api/v1/species/<species ID>
+```
+
+```http [Response]
+HTTP/1.1 200
+```
+:::

--- a/openfish-webapp/src/api.types.ts
+++ b/openfish-webapp/src/api.types.ts
@@ -5,6 +5,15 @@ export type Result<T> = {
   total: number
 }
 
+export type Species = {
+  id: number
+  species: string
+  common_name: string
+  images?: Image[]
+}
+
+export type Image = { src: string; attribution: string }
+
 export interface Annotation {
   id: number
   videostreamId: number


### PR DESCRIPTION
Adds a new API which we can use for suggesting species to a user when they are annotating video.

Currently, the API is not smart, it does not recommend species in any order, however my intention would be to make it return species from the current videostream first (sorted by frequency), then species from the current capture source (sorted by frequency), and then after that, the rest of the species (sorted by frequency).