### PR TITLE
Add user authentication using gcloud IAP

### DIFF
--- a/api/api/result_types.go
+++ b/api/api/result_types.go
@@ -71,3 +71,11 @@ func InvalidRequestJSON(err error) error {
 func InvalidRequestURL(err error) error {
 	return fiber.NewError(400, fmt.Errorf("invalid URL in request: %w", err).Error())
 }
+
+func Unauthorized(err error) error {
+	return fiber.NewError(401, fmt.Errorf("Unauthorized: %w", err).Error())
+}
+
+func Forbidden(err error) error {
+	return fiber.NewError(403, fmt.Errorf("Forbidden: %w", err).Error())
+}

--- a/api/handlers/annotations.go
+++ b/api/handlers/annotations.go
@@ -187,10 +187,13 @@ func CreateAnnotation(ctx *fiber.Ctx) error {
 		return api.InvalidRequestJSON(err)
 	}
 
+	// Get logged in user.
+	observer := ctx.Locals("email").(string)
+
 	// Write data to the datastore.
 	id, err := services.CreateAnnotation(body.VideoStreamID,
 		body.TimeSpan, body.BoundingBox,
-		body.Observer, body.Observation)
+		observer, body.Observation)
 	if err != nil {
 		return api.DatastoreWriteFailure(err)
 	}

--- a/api/handlers/auth.go
+++ b/api/handlers/auth.go
@@ -1,0 +1,51 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// handlers package handles HTTP requests.
+package handlers
+
+import (
+	"github.com/gofiber/fiber/v2"
+)
+
+type UserResult struct {
+	Email string `json:"email"`
+}
+
+// GetSelf gets information about the current user.
+func GetSelf(ctx *fiber.Ctx) error {
+	// Return user.
+	return ctx.JSON(UserResult{
+		Email: ctx.Locals("email").(string),
+	})
+}

--- a/api/main.go
+++ b/api/main.go
@@ -83,6 +83,9 @@ func registerAPIRoutes(app *fiber.App) {
 	v1.Get("/species/:id", handlers.GetSpeciesByID)
 	v1.Post("/species", handlers.CreateSpecies)
 	v1.Delete("/species/:id", handlers.DeleteSpecies)
+
+	// Auth.
+	v1.Get("/auth/me", handlers.GetSelf)
 }
 
 // errorHandler creates a HTTP response with the given status code or 500 by default.

--- a/app.yaml
+++ b/app.yaml
@@ -2,6 +2,9 @@ runtime: go120
 
 env_variables:
   OPENFISH_CREDENTIALS: gs://ausocean/OpenFish-a197b0443246.json
+  IAP: 'true'
+  FILESTORE: 'false'
+  JWT_AUDIENCE: '/projects/174291483773/apps/openfish'
 
 main: ./api/main.go
 


### PR DESCRIPTION
This adds support for user authentication using gcloud IAP. By default it is disabled, you need to pass the command line flag --iap or set the environmental argument IAP="true" to enable it. 

Command line flags and environmental arguments can now both be used to configure options.

IAP is active on https://openfish.appspot.com/streams.html