### PR TITLE
Add confirm dialog component

### DIFF
--- a/openfish-webapp/src/webcomponents/confirm-dialog.ts
+++ b/openfish-webapp/src/webcomponents/confirm-dialog.ts
@@ -1,0 +1,73 @@
+import { LitElement, css, html, unsafeCSS } from 'lit'
+import { customElement, property } from 'lit/decorators.js'
+import { type Ref, createRef, ref } from 'lit/directives/ref.js'
+import resetcss from '../styles/reset.css?raw'
+import btncss from '../styles/buttons.css?raw'
+
+@customElement('confirm-dialog')
+export class ConfirmDialog extends LitElement {
+  @property({ type: String })
+  confirmMessage = 'Yes'
+
+  @property({ type: String })
+  cancelMessage = 'No'
+
+  callback: () => void = () => {}
+
+  dialogRef: Ref<HTMLDialogElement> = createRef()
+
+  show(callback: () => void) {
+    this.dialogRef.value?.showModal()
+    this.callback = callback
+  }
+
+  confirm() {
+    this.dialogRef.value?.close()
+    this.callback()
+  }
+
+  cancel() {
+    this.dialogRef.value?.close()
+  }
+
+  render() {
+    return html`
+      <dialog ${ref(this.dialogRef)}>
+      <slot></slot>
+      <footer>
+        <button class="btn-orange btn-sm" @click=${this.confirm}>${this.confirmMessage}</button>
+        <button class="btn-secondary btn-sm" @click=${this.cancel}>${this.cancelMessage}</button>
+      </footer>
+      </dialog>
+    `
+  }
+
+  static styles = css`
+  ${unsafeCSS(resetcss)}
+  ${unsafeCSS(btncss)}
+
+  dialog {
+    border: none;
+    border-radius: 0.5rem;
+  }
+
+  ::backdrop {
+    background-color: var(--gray-950);
+    opacity: 0.5;
+  }
+
+  footer {
+    margin-top: 0.5rem;
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+    gap: 1rem;
+  }
+  `
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'confirm-dialog': ConfirmDialog
+  }
+}


### PR DESCRIPTION
Adds a dialog asking for user confirmation before performing an action.


### Usage

```html
<confirm-dialog>Your message here</confirm-dialog>
```

```typescript
const confirmDialog = document.querySelector("confirm-dialog") as ConfirmDialog

// show() displays the dialog, and takes a callback as an argument, that will
// fire if the user confirms.
confirmDialog.show(()=>console.log('user confirmed'))
```

### Screenshot
![image](https://github.com/ausocean/openfish/assets/33645953/11b8a8ca-00ac-491b-9ee2-2003e3bcbb59)
