### PR TITLE
Draft: Experimental: Add media API

### DIFF
--- a/api/entities/annotations.go
+++ b/api/entities/annotations.go
@@ -36,6 +36,8 @@ package entities
 
 import (
 	"encoding/json"
+	"errors"
+	"strings"
 	"time"
 
 	"github.com/ausocean/openfish/datastore"
@@ -48,6 +50,28 @@ const ANNOTATION_KIND = "Annotation"
 type TimeSpan struct {
 	Start time.Time `json:"start"`
 	End   time.Time `json:"end"`
+}
+
+func TimeSpanFromString(str string) (*TimeSpan, error) {
+	parts := strings.Split(str, "-")
+	if len(parts) != 2 {
+		return nil, errors.New("invalid time")
+	}
+
+	start, err := time.Parse(time.TimeOnly, parts[0])
+	if err != nil {
+		return nil, err
+	}
+	end, err := time.Parse(time.TimeOnly, parts[1])
+	if err != nil {
+		return nil, err
+	}
+
+	if end.Before(start) {
+		return nil, errors.New("start and end time provided in the wrong order")
+	}
+
+	return &TimeSpan{Start: start, End: end}, nil
 }
 
 // BoundingBox is a rectangle enclosing something interesting in a video.

--- a/api/main.go
+++ b/api/main.go
@@ -65,6 +65,7 @@ func registerAPIRoutes(app *fiber.App) {
 
 	// Video streams.
 	v1.Get("/videostreams/:id", handlers.GetVideoStreamByID)
+	v1.Get("/videostreams/:id/media", handlers.GetVideoStreamMedia)
 	v1.Get("/videostreams", handlers.GetVideoStreams)
 	v1.Post("/videostreams/live", handlers.StartVideoStream)
 	v1.Patch("/videostreams/:id/live", handlers.EndVideoStream)

--- a/docker/api
+++ b/docker/api
@@ -9,8 +9,9 @@ COPY go.mod go.sum ./
 RUN go build -o ./openfish-api ./api
 
 # Production container.
-FROM alpine:3.14 as production-stage
+FROM alpine:3.19 as production-stage
 WORKDIR /app
+RUN apk -U add yt-dlp
 COPY --from=build-stage /src/openfish-api ./
 EXPOSE 8080
 ENTRYPOINT [ "/app/openfish-api" ] 


### PR DESCRIPTION
To train a ML network to classify marine life automatically, we are going to need the media (video or images) associated with each annotation for our training dataset. This PR adds a media API for fetching the video data of a videostream between two times.

```http
GET /api/v1/videostreams/<videostream id>/media?time=00:00:01-00:00:03 HTTP/1.1
```

Downloading video from youtube is done by using yt-dlp to fetch and re-encode the video. This can be run locally using the provided dockerfile which installs this dependency. 

This feature is experimental because it is not going to work with appengine - our current method of deployment. Appengine only supports golang, and yt-dlp is a python program that also brings ffmpeg along too. Using the docker image we could deploy using Google Cloud Run, however, we need to assess costs, and if our usage would fall within the free tier. 


#### To-do
- [ ] support extracting single frames using the API
- [ ] add a build flag so that this feature can be optionally included
- [ ] pull timespan struct, parsing and formatting into different file.
- [ ] Make API use video times, not absolute times elsewhere to be consistent.