### PR TITLE
Add capturesource management page

### DIFF
--- a/openfish-webapp/capturesources.html
+++ b/openfish-webapp/capturesources.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" href="/favicon.ico" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenFish | Manage capture sources</title>
+    <link rel="stylesheet" href="./src/styles/index.css" />
+    <link rel="stylesheet" href="./src/styles/buttons.css" />
+
+    <script type="module" src="./src/webcomponents/site-nav.ts"></script>
+    <script type="module" src="./src/webcomponents/capturesource-list.ts"></script>
+
+    <style>
+      site-nav {
+        background-color: var(--bg);
+        border-color: var(--gray-100);
+      }
+      header {
+        grid-column: page;
+        display: flex;
+        justify-content: space-between;
+      }
+      capturesource-list {
+        grid-column: page;
+      }
+    </style>
+  </head>
+  <body class="grid-layout">
+    <site-nav></site-nav>
+    <header>
+      <h1>Manage capture sources</h1>
+      <button class="btn btn-blue" onclick="alert('placeholder dialog')">+ Create new capture source</button>
+    </header>
+      
+    <capturesource-list></capturesource-list>
+  </body>
+</html>

--- a/openfish-webapp/capturesources.html
+++ b/openfish-webapp/capturesources.html
@@ -10,6 +10,7 @@
 
     <script type="module" src="./src/webcomponents/site-nav.ts"></script>
     <script type="module" src="./src/webcomponents/capturesource-list.ts"></script>
+    <script type="module" src="./src/webcomponents/confirm-dialog.ts"></script>
 
     <style>
       site-nav {
@@ -24,15 +25,37 @@
       capturesource-list {
         grid-column: page;
       }
+
+
     </style>
+
+    <script type="module" >
+    const list = document.querySelector("capturesource-list")
+    const confirmDialog = document.querySelector("confirm-dialog")
+    const createBtn = document.querySelector("#create-btn")
+
+    async function deleteCaptureSource(id) {
+      try {
+        await fetch(
+          `${import.meta.env.VITE_API_HOST}/api/v1/capturesources/${id}`, { method: 'DELETE' }
+        )
+        list.fetchData()
+      } catch (error) {
+        console.error(error)
+      }
+    }
+
+    list.addEventListener("deleteitem", (e) => confirmDialog.show(()=> deleteCaptureSource(e.detail)))
+    </script>
   </head>
   <body class="grid-layout">
     <site-nav></site-nav>
     <header>
       <h1>Manage capture sources</h1>
-      <button class="btn btn-blue" onclick="alert('placeholder dialog')">+ Create new capture source</button>
+      <button class="btn btn-blue" id="create-btn">+ Create new capture source</button>
     </header>
       
     <capturesource-list></capturesource-list>
+    <confirm-dialog>Are you sure you want to delete this capture source?</confirm-dialog>
   </body>
 </html>

--- a/openfish-webapp/capturesources.html
+++ b/openfish-webapp/capturesources.html
@@ -11,7 +11,8 @@
     <script type="module" src="./src/webcomponents/site-nav.ts"></script>
     <script type="module" src="./src/webcomponents/capturesource-list.ts"></script>
     <script type="module" src="./src/webcomponents/confirm-dialog.ts"></script>
-
+    <script type="module" src="./src/webcomponents/create-capture-source-dialog.ts"></script>
+    
     <style>
       site-nav {
         background-color: var(--bg);
@@ -32,6 +33,7 @@
     <script type="module" >
     const list = document.querySelector("capturesource-list")
     const confirmDialog = document.querySelector("confirm-dialog")
+    const createCaptureSourceDialog = document.querySelector("create-capture-source-dialog")
     const createBtn = document.querySelector("#create-btn")
 
     async function deleteCaptureSource(id) {
@@ -46,6 +48,8 @@
     }
 
     list.addEventListener("deleteitem", (e) => confirmDialog.show(()=> deleteCaptureSource(e.detail)))
+    createBtn.addEventListener("click", () => createCaptureSourceDialog.show())
+    createCaptureSourceDialog.addEventListener("createitem", ()=>list.fetchData())
     </script>
   </head>
   <body class="grid-layout">
@@ -56,6 +60,8 @@
     </header>
       
     <capturesource-list></capturesource-list>
+
     <confirm-dialog>Are you sure you want to delete this capture source?</confirm-dialog>
+    <create-capture-source-dialog></create-capture-source-dialog>
   </body>
 </html>

--- a/openfish-webapp/src/webcomponents/capturesource-list.ts
+++ b/openfish-webapp/src/webcomponents/capturesource-list.ts
@@ -1,0 +1,146 @@
+import { LitElement, css, html, unsafeCSS } from 'lit'
+import { customElement, state } from 'lit/decorators.js'
+import type { CaptureSource, Result } from '../utils/api.types.ts'
+import { repeat } from 'lit/directives/repeat.js'
+import resetcss from '../styles/reset.css?raw'
+
+@customElement('capturesource-list')
+export class CaptureSourceList extends LitElement {
+  @state()
+  protected _page = 1
+
+  @state()
+  protected _items: CaptureSource[] = []
+
+  @state()
+  protected _totalPages = 0
+
+  connectedCallback() {
+    super.connectedCallback()
+    this.fetchData()
+  }
+
+  async fetchData() {
+    const perPage = 10
+
+    try {
+      const params = new URLSearchParams()
+      params.set('limit', String(10))
+      params.set('offset', String((this._page - 1) * perPage))
+
+      const res = await fetch(
+        `${import.meta.env.VITE_API_HOST}/api/v1/capturesources?${params.toString()}`
+      )
+      const data = (await res.json()) as Result<CaptureSource>
+      this._items = data.results
+      this._totalPages = Math.floor(data.total / perPage)
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  prev() {
+    this._page += 1
+    this.fetchData()
+  }
+
+  next() {
+    this._page -= 1
+    this.fetchData()
+  }
+
+  render() {
+    const header = html`
+    <tr>
+      <th>Name</th>
+      <th>Camera Hardware</th>
+      <th>Site ID</th>
+      <th>Location</th>
+    </tr>
+    `
+
+    const rows = (source: CaptureSource) => html`
+    <tr>
+      <td>${source.name}</td>
+      <td>${source.camera_hardware}</td>
+      <td>${source.site_id ?? '-'}</td>
+      <td>${source.location}</td>
+    </tr>
+    `
+
+    const pagination = html`   
+    <span class="mr-1">Page ${this._page} of ${this._totalPages}</span>
+    <button @click="${this.next}" .disabled=${this._page === 1}>Prev</button>
+    <button @click="${this.prev}" .disabled=${this._page === this._totalPages}>Next</button>
+    `
+
+    return html`
+    <table>
+    <thead>
+      ${header}
+    </thead>
+    <tbody>
+      ${repeat(this._items, rows)}
+    </tbody>
+    <tfoot>
+      ${pagination}
+    </tfoot>
+    </table>
+    `
+  }
+
+  static styles = css`
+    ${unsafeCSS(resetcss)}
+
+    table {
+      display: grid;  
+      grid-template-columns: 1fr 1fr 1fr 1fr;
+      border-radius: 0.25rem;
+      border: 1px solid var(--gray-100);
+    }
+
+    thead, tbody, tr {
+      display: contents;
+    }
+
+    tbody td {
+      padding: 0.5rem 1rem;
+      border-bottom: 1px solid var(--gray-100);
+    }
+    tr {
+      cursor: pointer
+    }
+    tr:hover td {
+      background-color: var(--gray-50);
+      color: var(--blue-700)
+    }
+
+    thead th {
+      background-color: var(--gray-50);
+      border-bottom: 1px solid var(--gray-100);
+      padding: 0.5em 0;
+    }
+
+    tfoot {
+      background-color: var(--gray-50);
+      padding: 0.5em 0;
+      grid-column: 1/ span 4;
+      display: flex;
+      justify-content: center;
+      gap: 0.25rem
+    }
+
+    th {
+      padding: 0.5rem
+    }
+    
+    td {
+      text-align: center
+    }`
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'capturesource-list': CaptureSourceList
+  }
+}

--- a/openfish-webapp/src/webcomponents/capturesource-list.ts
+++ b/openfish-webapp/src/webcomponents/capturesource-list.ts
@@ -3,6 +3,9 @@ import { customElement, state } from 'lit/decorators.js'
 import type { CaptureSource, Result } from '../utils/api.types.ts'
 import { repeat } from 'lit/directives/repeat.js'
 import resetcss from '../styles/reset.css?raw'
+import btncss from '../styles/buttons.css?raw'
+
+export type DeleteItemEvent = CustomEvent<number>
 
 @customElement('capturesource-list')
 export class CaptureSourceList extends LitElement {
@@ -49,6 +52,10 @@ export class CaptureSourceList extends LitElement {
     this.fetchData()
   }
 
+  dispatchDeleteItemEvent(id: number) {
+    this.dispatchEvent(new CustomEvent('deleteitem', { detail: id }) as DeleteItemEvent)
+  }
+
   render() {
     const header = html`
     <tr>
@@ -56,6 +63,7 @@ export class CaptureSourceList extends LitElement {
       <th>Camera Hardware</th>
       <th>Site ID</th>
       <th>Location</th>
+      <th></th>
     </tr>
     `
 
@@ -65,6 +73,8 @@ export class CaptureSourceList extends LitElement {
       <td>${source.camera_hardware}</td>
       <td>${source.site_id ?? '-'}</td>
       <td>${source.location}</td>
+      <td><button class="btn btn-sm btn-secondary" @click=${() =>
+        this.dispatchDeleteItemEvent(source.id)}>Delete</button></td>
     </tr>
     `
 
@@ -91,10 +101,11 @@ export class CaptureSourceList extends LitElement {
 
   static styles = css`
     ${unsafeCSS(resetcss)}
+    ${unsafeCSS(btncss)}
 
     table {
       display: grid;  
-      grid-template-columns: 1fr 1fr 1fr 1fr;
+      grid-template-columns: 1fr 1fr 1fr 1fr min-content;
       border-radius: 0.25rem;
       border: 1px solid var(--gray-100);
     }
@@ -124,7 +135,7 @@ export class CaptureSourceList extends LitElement {
     tfoot {
       background-color: var(--gray-50);
       padding: 0.5em 0;
-      grid-column: 1/ span 4;
+      grid-column: 1/-1;
       display: flex;
       justify-content: center;
       gap: 0.25rem

--- a/openfish-webapp/src/webcomponents/create-capture-source-dialog.ts
+++ b/openfish-webapp/src/webcomponents/create-capture-source-dialog.ts
@@ -1,0 +1,129 @@
+import { LitElement, css, html, unsafeCSS } from 'lit'
+import { customElement } from 'lit/decorators.js'
+import { type Ref, createRef, ref } from 'lit/directives/ref.js'
+import resetcss from '../styles/reset.css?raw'
+import btncss from '../styles/buttons.css?raw'
+import './location-picker.ts'
+import type { CaptureSource } from '../utils/api.types.ts'
+
+@customElement('create-capture-source-dialog')
+export class CreateCaptureSourceDialog extends LitElement {
+  dialogRef: Ref<HTMLDialogElement> = createRef()
+
+  show() {
+    this.dialogRef.value?.showModal()
+  }
+
+  async submit(e: SubmitEvent) {
+    e.preventDefault()
+
+    const formdata = new FormData(e.target as HTMLFormElement)
+    const payload: Partial<CaptureSource> = {
+      name: formdata.get('name')?.toString(),
+      camera_hardware: formdata.get('camera_hardware')?.toString(),
+      location: formdata.get('location')?.toString() as `${number},${number}`,
+    }
+
+    if (formdata.get('site_id')) {
+      payload.site_id = Number(formdata.get('site_id'))
+    }
+
+    await fetch(`${import.meta.env.VITE_API_HOST}/api/v1/capturesources`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    })
+
+    this.dialogRef.value?.close()
+    this.dispatchEvent(new Event('createitem'))
+  }
+
+  cancel() {
+    this.dialogRef.value?.close()
+  }
+
+  render() {
+    return html`
+      <dialog ${ref(this.dialogRef)}>
+      <h3>Create a new capture source</h3>
+      <form @submit=${this.submit}>
+        <section>
+          <label for="name">Name</label>
+          <input type="text" id="name" name="name" placeholder="Enter name of the capture source" required />
+        </section>
+
+        <section>
+          <label for="camera_hardware">Camera Hardware</label>
+          <input type="text" id="camera_hardware" name="camera_hardware" placeholder="Enter description of camera hardware" required />
+        </section>
+
+        <section>
+          <label for="site_id">Site ID</label>
+          <input type="text" id="site_id" name="site_id" placeholder="Enter site ID (optional)"  />
+        </section>
+
+        <section>
+          <label>Location</label>
+          <location-picker id="location" name="location" ></location-picker>
+        </section>
+
+
+      <footer>
+        <input class="btn-orange btn-sm" type="submit" value="Create Capture Source" />
+        
+        <button class="btn-secondary btn-sm" @click=${this.cancel}>Cancel</button>
+      </footer>
+      </form>
+      </dialog>
+    `
+  }
+
+  static styles = css`
+  ${unsafeCSS(resetcss)}
+  ${unsafeCSS(btncss)}
+
+  dialog {
+    border: none;
+    border-radius: 0.5rem;
+    min-width: 30rem;
+  }
+
+  ::backdrop {
+    background-color: var(--gray-950);
+    opacity: 0.5;
+  }
+
+  form {
+    margin-top: 1rem;
+    padding: 1.5rem 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  input, label {
+    display: block;
+    width: 100%;
+  }
+
+
+  label {
+    margin-top: -0.5rem;
+    margin-bottom: 0.25rem;
+  }
+
+  footer {
+    margin-top: 1rem;
+    display: flex;
+    width: 100%;
+    justify-content: flex-end;
+    gap: 1rem;
+  }
+  `
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'create-capturesource-dialog': CreateCaptureSourceDialog
+  }
+}


### PR DESCRIPTION
Adds a capturesource management page so users can create, view and delete capture sources without needing to manually send HTTP requests to the API. Currently, no restrictions on who can use this but it will be restricted to only admin users