### PR TITLE
Add role based access control

### DIFF
--- a/api/entities/users.go
+++ b/api/entities/users.go
@@ -1,0 +1,127 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package entities
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ausocean/openfish/datastore"
+)
+
+// TODO: implement user entity.
+
+// Kind of entity to store / fetch from the datastore.
+const USER_KIND = "User"
+
+// User contains the user role and email address.
+type User struct {
+	Email string
+	Role  Role
+}
+
+// Role enum.
+type Role int8
+
+const (
+	ReadonlyRole  Role = iota // Can only use GET APIs.
+	AnnotatorRole             // Can create annotations.
+	CuratorRole               // Can create annotations and videostreams.
+	AdminRole                 // Can do everything.
+	DefaultRole   = AnnotatorRole
+)
+
+func (r Role) String() string {
+	switch r {
+	case ReadonlyRole:
+		return "readonly"
+	case AnnotatorRole:
+		return "annotator"
+	case CuratorRole:
+		return "curator"
+	case AdminRole:
+		return "admin"
+	}
+	return "unknown"
+}
+
+func ParseRole(s string) (Role, error) {
+	switch s {
+	case "readonly":
+		return ReadonlyRole, nil
+	case "annotator":
+		return AnnotatorRole, nil
+	case "curator":
+		return CuratorRole, nil
+	case "admin":
+		return AdminRole, nil
+	}
+	return DefaultRole, fmt.Errorf("invalid role provided: %s", s)
+}
+
+// Encode serializes User. Implements Entity interface. Used for FileStore datastore.
+func (vs *User) Encode() []byte {
+	bytes, _ := json.Marshal(vs)
+	return bytes
+}
+
+// Encode deserializes User. Implements Entity interface. Used for FileStore datastore.
+func (vs *User) Decode(b []byte) error {
+	return json.Unmarshal(b, vs)
+}
+
+// Implements Copy from the Entity interface.
+func (vs *User) Copy(dst datastore.Entity) (datastore.Entity, error) {
+	var v *User
+	if dst == nil {
+		v = new(User)
+	} else {
+		var ok bool
+		v, ok = dst.(*User)
+		if !ok {
+			return nil, datastore.ErrWrongType
+		}
+	}
+	*v = *vs
+	return v, nil
+}
+
+// No caching is used.
+func (vs *User) GetCache() datastore.Cache {
+	return nil
+}
+
+func NewUser() datastore.Entity {
+	return &User{}
+}

--- a/api/handlers/auth.go
+++ b/api/handlers/auth.go
@@ -35,17 +35,15 @@ LICENSE
 package handlers
 
 import (
+	"github.com/ausocean/openfish/api/entities"
 	"github.com/gofiber/fiber/v2"
 )
-
-type UserResult struct {
-	Email string `json:"email"`
-}
 
 // GetSelf gets information about the current user.
 func GetSelf(ctx *fiber.Ctx) error {
 	// Return user.
 	return ctx.JSON(UserResult{
 		Email: ctx.Locals("email").(string),
+		Role:  ctx.Locals("role").(entities.Role).String(),
 	})
 }

--- a/api/handlers/capturesource.go
+++ b/api/handlers/capturesource.go
@@ -236,6 +236,7 @@ func UpdateCaptureSource(ctx *fiber.Ctx) error {
 
 // DeleteCaptureSource deletes a capture source.
 func DeleteCaptureSource(ctx *fiber.Ctx) error {
+
 	// Parse URL.
 	id, err := strconv.ParseInt(ctx.Params("id"), 10, 64)
 	if err != nil {

--- a/api/handlers/user.go
+++ b/api/handlers/user.go
@@ -1,0 +1,151 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// handlers package handles HTTP requests.
+package handlers
+
+import (
+	"github.com/ausocean/openfish/api/api"
+	"github.com/ausocean/openfish/api/entities"
+	"github.com/ausocean/openfish/api/services"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+// UserResult describes the JSON format for users in API responses.
+type UserResult struct {
+	Email string `json:"email"`
+	Role  string `json:"role"`
+}
+
+// FromUserEntity creates a UserResult from a entities.User.
+func FromUserEntity(user *entities.User) UserResult {
+	return UserResult{Email: user.Email, Role: user.Role.String()}
+}
+
+// GetUsersQuery describes the URL query parameters required for the GetUsers endpoint.
+type GetUsersQuery struct {
+	api.LimitAndOffset
+}
+
+// UpdateUserBody describes the JSON format required for the UpdateUser endpoint.
+type UpdateUserBody struct {
+	Role string `json:"role"` // Required.
+}
+
+// GetUserByEmail gets a user when provided with an email.
+func GetUserByEmail(ctx *fiber.Ctx) error {
+	// Parse URL.
+	email := ctx.Params("email")
+
+	// Fetch data from the datastore.
+	user, err := services.GetUserByEmail(email)
+	if err != nil {
+		return api.DatastoreReadFailure(err)
+	}
+
+	// Format result.
+	result := FromUserEntity(user)
+	return ctx.JSON(result)
+}
+
+// GetUsers gets a list of users.
+// TODO: support filtering by role.
+func GetUsers(ctx *fiber.Ctx) error {
+	// Parse URL.
+	qry := new(GetUsersQuery)
+	qry.SetLimit()
+
+	if err := ctx.QueryParser(qry); err != nil {
+		return api.InvalidRequestURL(err)
+	}
+
+	// Fetch data from the datastore.
+	users, err := services.GetUsers(qry.Limit, qry.Offset)
+	if err != nil {
+		return api.DatastoreReadFailure(err)
+	}
+
+	// Format results.
+	results := make([]UserResult, len(users))
+	for i := range users {
+		results[i] = FromUserEntity(&users[i])
+	}
+
+	return ctx.JSON(api.Result[UserResult]{
+		Results: results,
+		Offset:  qry.Offset,
+		Limit:   qry.Limit,
+		Total:   len(results),
+	})
+}
+
+// UpdateUser updates a user.
+func UpdateUser(ctx *fiber.Ctx) error {
+	// Parse URL.
+	email := ctx.Params("email")
+
+	// Parse body.
+	var body UpdateUserBody
+	err := ctx.BodyParser(&body)
+	if err != nil {
+		return api.InvalidRequestJSON(err)
+	}
+
+	role, err := entities.ParseRole(body.Role)
+	if err != nil {
+		return api.InvalidRequestJSON(err)
+	}
+
+	// Update data in the datastore.
+	err = services.UpdateUser(email, role)
+	if err != nil {
+		return api.DatastoreWriteFailure(err)
+	}
+
+	return nil
+}
+
+// DeleteUser deletes a user.
+func DeleteUser(ctx *fiber.Ctx) error {
+	// Parse URL.
+	email := ctx.Params("email")
+
+	// Delete capture source.
+	err := services.DeleteUser(email)
+	if err != nil {
+		return api.DatastoreWriteFailure(err)
+	}
+
+	return nil
+}

--- a/api/middleware/authentication.go
+++ b/api/middleware/authentication.go
@@ -1,0 +1,104 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package middleware
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ausocean/openfish/api/api"
+	"github.com/ausocean/openfish/api/entities"
+	"github.com/ausocean/openfish/api/services"
+	"github.com/gofiber/fiber/v2"
+	"google.golang.org/api/idtoken"
+)
+
+// ValidateJWT creates a validator middleware that validate JWT tokens returned from Google IAP.
+// Otherwise, it returns a 401 Unauthorized http error.
+// See more: https://cloud.google.com/iap/docs/signed-headers-howto#iap_validate_jwt-go
+func ValidateJWT(aud string) func(*fiber.Ctx) error {
+
+	fmt.Println("jwt audience: ", aud)
+
+	return func(ctx *fiber.Ctx) error {
+
+		// Get JWT from header.
+		iapJWT := ctx.Get("X-Goog-IAP-JWT-Assertion")
+
+		// Validate JWT token.
+		payload, err := idtoken.Validate(context.Background(), iapJWT, aud)
+		if err != nil {
+			return api.Unauthorized(err)
+		}
+
+		// Extract subject and email.
+		email := payload.Claims["email"].(string)
+		subject := payload.Subject
+		role := entities.DefaultRole
+
+		// Fetch user from datastore if they exist, else
+		// create new user.
+		user, err := services.GetUserByEmail(email)
+		if err != nil {
+			services.CreateUser(email, role)
+		} else {
+			role = user.Role
+		}
+
+		// Add subject, email, and user role to ctx.Locals.
+		ctx.Locals("subject", subject)
+		ctx.Locals("email", email)
+		ctx.Locals("role", role)
+
+		return ctx.Next()
+	}
+}
+
+func Guard(requiredRole entities.Role) func(*fiber.Ctx) error {
+
+	return func(ctx *fiber.Ctx) error {
+		// Skip if IAP authentication is disabled.
+		if ctx.Locals("role") == nil {
+			return ctx.Next()
+		}
+
+		userRole := ctx.Locals("role").(entities.Role)
+		if userRole >= requiredRole {
+			return ctx.Next()
+		} else {
+			return api.Forbidden(fmt.Errorf("this operation requires %s role, requesting user has %s role", requiredRole.String(), userRole.String()))
+		}
+
+	}
+}

--- a/api/services/capturesource_test.go
+++ b/api/services/capturesource_test.go
@@ -49,6 +49,7 @@ func setup() {
 	_ = os.Mkdir("store/openfish/VideoStream", os.ModePerm)
 	_ = os.Mkdir("store/openfish/Annotation", os.ModePerm)
 	_ = os.Mkdir("store/openfish/Species", os.ModePerm)
+	_ = os.Mkdir("store/openfish/Users", os.ModePerm)
 
 }
 

--- a/api/services/users.go
+++ b/api/services/users.go
@@ -1,0 +1,122 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package services
+
+import (
+	"context"
+
+	"github.com/ausocean/openfish/api/ds_client"
+	"github.com/ausocean/openfish/api/entities"
+	"github.com/ausocean/openfish/datastore"
+)
+
+// GetUserByEmail gets a user when provided with an email.
+func GetUserByEmail(email string) (*entities.User, error) {
+	store := ds_client.Get()
+	key := store.NameKey(entities.USER_KIND, email)
+	var user entities.User
+	err := store.Get(context.Background(), key, &user)
+	if err != nil {
+		return nil, err
+	}
+	return &user, nil
+}
+
+func UserExists(email string) bool {
+	store := ds_client.Get()
+	key := store.NameKey(entities.USER_KIND, email)
+	var user entities.User
+	err := store.Get(context.Background(), key, &user)
+	return err == nil
+}
+
+// GetUsers gets a list of users.
+func GetUsers(limit int, offset int) ([]entities.User, error) {
+
+	// Fetch data from the datastore.
+	store := ds_client.Get()
+	query := store.NewQuery(entities.USER_KIND, false)
+
+	query.Limit(limit)
+	query.Offset(offset)
+
+	var users []entities.User
+	_, err := store.GetAll(context.Background(), query, &users)
+	if err != nil {
+		return []entities.User{}, err
+	}
+
+	return users, nil
+}
+
+// CreateUser creates a new user.
+func CreateUser(email string, role entities.Role) error {
+
+	// Use the user's email as a unique ID.
+	store := ds_client.Get()
+	key := store.NameKey(entities.USER_KIND, email)
+
+	user := entities.User{
+		Email: email,
+		Role:  role,
+	}
+
+	// Add to datastore.
+	_, err := store.Put(context.Background(), key, &user)
+	return err
+}
+
+// UpdateUser updates a user's role.
+func UpdateUser(email string, role entities.Role) error {
+
+	// Update data in the datastore.
+	store := ds_client.Get()
+	key := store.NameKey(entities.USER_KIND, email)
+	var user entities.User
+
+	return store.Update(context.Background(), key, func(e datastore.Entity) {
+		v, ok := e.(*entities.User)
+		if ok {
+			v.Role = role
+		}
+	}, &user)
+}
+
+// DeleteUser deletes a user.
+func DeleteUser(email string) error {
+	// Delete entity.
+	store := ds_client.Get()
+	key := store.NameKey(entities.USER_KIND, email)
+	return store.Delete(context.Background(), key)
+}

--- a/api/services/users_test.go
+++ b/api/services/users_test.go
@@ -1,0 +1,166 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package services_test
+
+import (
+	"testing"
+
+	"github.com/ausocean/openfish/api/entities"
+	"github.com/ausocean/openfish/api/services"
+)
+
+func TestCreateUser(t *testing.T) {
+	setup()
+
+	// Create a new user entity.
+	err := services.CreateUser("test@test.com", entities.DefaultRole)
+	if err != nil {
+		t.Errorf("Could not create user entity %s", err)
+	}
+}
+
+func TestUserExists(t *testing.T) {
+	setup()
+
+	// Create a new user entity.
+	services.CreateUser("test@test.com", entities.DefaultRole)
+
+	// Check if the user exists.
+	if !services.UserExists("test@test.com") {
+		t.Errorf("Expected user to exist")
+	}
+}
+
+func TestUserExistsForNonexistentEntity(t *testing.T) {
+	setup()
+
+	// Check if the user exists.
+	// We expect it to return false.
+	if services.UserExists("nonexistent@test.com") {
+		t.Errorf("Did not expect user to exist")
+	}
+}
+
+func TestGetUserByEmail(t *testing.T) {
+	setup()
+
+	// Define test cases.
+	testCases := []struct {
+		email string
+		role  entities.Role
+	}{
+		{"admin@test.com", entities.AdminRole},
+		{"curator@test.com", entities.CuratorRole},
+		{"annotator@test.com", entities.AnnotatorRole},
+		{"readonly@test.com", entities.ReadonlyRole},
+	}
+
+	for _, tc := range testCases {
+		// Create user entities for each test case.
+		services.CreateUser(tc.email, tc.role)
+
+		// Check if the user can be fetched and is the same.
+		user, err := services.GetUserByEmail(tc.email)
+		if err != nil {
+			t.Errorf("Could not get user entity %s", err)
+		}
+		if user.Email != tc.email || user.Role != tc.role {
+			t.Errorf("User entity does not match created entity")
+		}
+	}
+}
+
+func TestGetUserByEmailForNonexistentEntity(t *testing.T) {
+	setup()
+
+	user, err := services.GetUserByEmail("nonexistent@test.com")
+	if user != nil && err == nil {
+		t.Errorf("GetUserByEmail returned non-existing entity %s", err)
+	}
+}
+
+func TestUpdateUser(t *testing.T) {
+	setup()
+
+	// Create a new user entity.
+	services.CreateUser("test@test.com", entities.DefaultRole)
+
+	// Update the role.
+	role := entities.AdminRole
+	err := services.UpdateUser("test@test.com", role)
+	if err != nil {
+		t.Errorf("Could not update user entity %s", err)
+	}
+
+	user, _ := services.GetUserByEmail("test@test.com")
+	if user.Role != role {
+		t.Errorf("Role did not update, expected %s, actual %s", role.String(), user.Role.String())
+	}
+}
+
+func TestUpdateUserForNonExistentEntity(t *testing.T) {
+	setup()
+
+	err := services.UpdateUser("nonexistent@test.com", entities.AdminRole)
+	if err == nil {
+		t.Errorf("Did not receive expected error when updating non-existent user")
+	}
+}
+
+func TestDeleteUser(t *testing.T) {
+	setup()
+
+	// Create a new user entity.
+	services.CreateUser("test@test.com", entities.DefaultRole)
+
+	// Delete the capture source entity.
+	err := services.DeleteUser("test@test.com")
+	if err != nil {
+		t.Errorf("Could not delete user entity")
+	}
+
+	// Check if the capture source exists.
+	if services.UserExists("test@test.com") {
+		t.Errorf("User entity exists after delete")
+	}
+}
+
+func TestDeleteUserForNonexistentEntity(t *testing.T) {
+	setup()
+
+	err := services.DeleteUser("nonexistent@test.com")
+	if err == nil {
+		t.Errorf("Did not receive expected error when deleting non-existent capture source")
+	}
+}


### PR DESCRIPTION
Closes #115 

Adds the concept of users to openfish. Users are identified by their email address. Users have one of 4 roles.

**Admin role**
An admin would be able to add and remove annotations, videostreams, capturesources, users, and species.

**Curator role**
A curator can select streams for classification. An application would be for teachers who could choose streams for their students to classify

**Annotator role**
By default users would have the annotator role, which lets them add annotations, and delete their own annotations.

**Readonly role**
A readonly user would only be able to look at annotations, not make any. This could be for unauthenticated users who only want to watch.

A new middleware - Guard is used to restrict access to APIs by user role. **When ran locally (non-iap mode), role based access is disabled.** 

A new user API exists for managing users. New users cannot be created - a user is created when they log in for the first time. By default they are given the annotator role. The API supports:
- getting a single user
- getting many users
- updating a user's role
- deleting a user

The API is restricted for Admins only for now, we can change that later if needed.




