### PR TITLE
Add documentation on roles, users and authentication

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -23,11 +23,14 @@ export default defineConfig({
         text: 'API Documentation',
         items: [
           { text: 'Introduction', link: '/api/'},
+          { text: 'Authentication', link: '/api/authentication'},
+          { text: 'Roles and Permissions', link: '/api/roles-and-permissions'},
           { text: 'API Usage', link: '/api/api-usage', items: [
             { text: 'Capture Sources', link: '/api/capture-sources'},
             { text: 'Video Streams', link: '/api/video-streams'},
             { text: 'Annotations', link: '/api/annotations'},
             { text: 'Species', link: '/api/species'},
+            { text: 'Users', link: '/api/users'},
           ]},
 
         ]

--- a/docs/api/authentication.md
+++ b/docs/api/authentication.md
@@ -1,0 +1,8 @@
+# Authentication
+**Authors:** Scott Barnard
+
+OpenFish has optional support for requiring user authentication. 
+
+User authentication is provided using gcloud IAP. By default it is disabled, you need to pass the command line flag --iap or set the environmental argument IAP="true" to enable it.
+
+Command line flags and environmental arguments can now both be used to configure options.

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,10 +4,12 @@
 OpenFish provides an API to access stored marine footage, and video annotations / labels, allowing clients to retrieve and filter the data.
 Clients can download segments of footage or video annotations by querying by location, time, and other parameters.
 
-OpenFish's API has three types of resources it deals with: [capture sources][capture-sources], [video streams][video-streams] and [annotations][annotations]. Capture sources are cameras that produces video streams, video streams have information about a single video and annotations are used for labeling interesting things at a particular time and place in videos. 
+OpenFish's API has a few types of resources it deals with: [capture sources][capture-sources], [video streams][video-streams], [annotations][annotations], [species][species] and [users][users]. Capture sources are cameras that produces video streams. Video streams have information about a single video. Annotations are used for labeling interesting things at a particular time and place in videos. Species provides a list of valid species for users to identify. Users contains the user's [role and permissions][roles-permissions].
 
-[general-usage-notes]: ./api-usage
 [capture-sources]: ./capture-sources
 [video-streams]: ./video-streams
 [annotations]: ./annotations
+[species]: ./species
+[users]: ./users
+[roles-permissions]: ./roles-and-permissions
 

--- a/docs/api/roles-and-permissions.md
+++ b/docs/api/roles-and-permissions.md
@@ -1,0 +1,16 @@
+# Roles and Permissions
+**Authors:** Scott Barnard
+
+Users can have the following roles and permissions:
+
+### Admin role
+Admins are able to add and remove annotations, videostreams, capturesources, users, and species.
+
+### Curator role
+A curator can select streams for classification. An example of when this is useful: for teachers who could choose streams for their students to classify
+
+### Annotator role
+By default users are given the annotator role, which lets them add annotations, and delete their own annotations.
+
+### Readonly role
+A readonly user is only be able to look at annotations, not make any.

--- a/docs/api/users.md
+++ b/docs/api/users.md
@@ -1,0 +1,83 @@
+# Users
+**Authors:** Scott Barnard
+
+A user is identified by their email and has a role that gives them permissions. A user is created
+when they first login to OpenFish. There are APIs for updating user's role, listing users and
+deleting a user account.
+
+
+## Fetching a user's details.
+::: code-group
+```http [Request]
+GET /api/v1/users/<user email address>
+```
+
+```http [Response]
+HTTP/1.1 200
+content-type: application/json
+
+{
+  "email": "user@example.com",
+  "role": "annotator"
+}
+```
+:::
+
+## Listing users
+This will show a list of all users. This is restricted to admins only.
+
+::: code-group
+```http [Request]
+GET /api/v1/users
+```
+
+```http [Response]
+HTTP/1.1 200
+content-type: application/json
+
+{
+  "results": [
+    {
+      "email": "user@example.com",
+      "role": "annotator"
+    }
+  ],
+  "offset": 0,
+  "limit": 20,
+  "total": 1
+}
+```
+:::
+
+
+## Updating a user's role
+User role can be updated using PATCH. Successful update operation will return 200 OK.
+::: code-group
+```http [Request]
+PATCH /api/v1/users/<user email address>
+content-type: application/json
+
+{
+  "role": "admin"
+}
+```
+
+```http [Response]
+HTTP/1.1 200
+```
+:::
+
+
+## Deleting a user
+Successful delete will return 200 OK.
+
+
+::: code-group
+```http [Request]
+DELETE /api/v1/users/<user email address>
+```
+
+```http [Response]
+HTTP/1.1 200
+```
+:::


### PR DESCRIPTION
We recently added user authentication (PR #108) and user roles / permissions (PR #122), which adds new APIs (for managing users), adds new ways existing APIs can fail (unauthorised & forbidden HTTP codes) and a new command line flag, so these need to be documented.