### PR TITLE
Add species import API from iNaturalist

### DIFF
--- a/api/entities/species.go
+++ b/api/entities/species.go
@@ -44,9 +44,10 @@ const SPECIES_KIND = "Species"
 
 // Species is used for our guide.
 type Species struct {
-	Species    string
-	CommonName string
-	Images     []Image
+	Species            string
+	CommonName         string
+	Images             []Image
+	INaturalistTaxonID *int // Optional.
 }
 
 type Image struct {

--- a/api/main.go
+++ b/api/main.go
@@ -85,6 +85,7 @@ func registerAPIRoutes(app *fiber.App) {
 		Get("/recommended", handlers.GetRecommendedSpecies).
 		Get("/:id", handlers.GetSpeciesByID).
 		Post("/", middleware.Guard(entities.AdminRole), handlers.CreateSpecies).
+		Post("/import-from-inaturalist", middleware.Guard(entities.AdminRole), handlers.ImportFromINaturalist).
 		Delete("/:id", middleware.Guard(entities.AdminRole), handlers.DeleteSpecies)
 
 	// Users.

--- a/api/services/species_test.go
+++ b/api/services/species_test.go
@@ -44,7 +44,7 @@ func TestCreateSpecies(t *testing.T) {
 	setup()
 
 	// Create a new species entity.
-	_, err := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0))
+	_, err := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0), nil)
 	if err != nil {
 		t.Errorf("Could not create species entity %s", err)
 	}
@@ -54,7 +54,7 @@ func TestSpeciesExists(t *testing.T) {
 	setup()
 
 	// Create a new species entity.
-	id, _ := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0))
+	id, _ := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0), nil)
 
 	// Check if the species exists.
 	if !services.SpeciesExists(int64(id)) {
@@ -76,7 +76,7 @@ func TestGetSpeciesByID(t *testing.T) {
 	setup()
 
 	// Create a new species entity.
-	id, _ := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0))
+	id, _ := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0), nil)
 
 	species, err := services.GetSpeciesByID(int64(id))
 	if err != nil {
@@ -102,7 +102,7 @@ func TestDeleteSpecies(t *testing.T) {
 	setup()
 
 	// Create a new species entity.
-	id, _ := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0))
+	id, _ := services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0), nil)
 
 	// Delete the species entity.
 	err := services.DeleteSpecies(int64(id))


### PR DESCRIPTION
Related to issue #127 

Adds an API to import species from iNaturalist, updating existing species with changes, or creating new records in the datastore if they do not already exist.
