### PR TITLE
Use playback time instead of timestamps for annotations (API only)

### DIFF
--- a/cmd/openfish/entities/annotations.go
+++ b/cmd/openfish/entities/annotations.go
@@ -36,18 +36,24 @@ package entities
 
 import (
 	"encoding/json"
-	"time"
 
+	"github.com/ausocean/openfish/cmd/openfish/types/videotime"
 	"github.com/ausocean/openfish/datastore"
 )
 
 // Kind of entity to store / fetch from the datastore.
 const ANNOTATION_KIND = "Annotation"
 
-// TimeSpan is a pair of timestamps - start time and end time.
+// TimeSpan is a pair of video timestamps - start time and end time.
 type TimeSpan struct {
-	Start time.Time `json:"start"`
-	End   time.Time `json:"end"`
+	Start videotime.VideoTime `json:"start"`
+	End   videotime.VideoTime `json:"end"`
+}
+
+// Validate tests that the start time occurs before the end time.
+func (t TimeSpan) Validate() error {
+	// TODO: Implement timespan validation.
+	return nil
 }
 
 // BoundingBox is a rectangle enclosing something interesting in a video.

--- a/cmd/openfish/handlers/videostream.go
+++ b/cmd/openfish/handlers/videostream.go
@@ -35,7 +35,6 @@ LICENSE
 package handlers
 
 import (
-	"errors"
 	"strconv"
 	"time"
 
@@ -159,11 +158,9 @@ func GetVideoStreams(ctx *fiber.Ctx) error {
 		return api.InvalidRequestURL(err)
 	}
 
-	// Validate timespan
-	if qry.TimeSpan != nil {
-		if qry.TimeSpan.Start.After(qry.TimeSpan.End) {
-			return api.InvalidRequestURL(errors.New("start time not before end time"))
-		}
+	// Validate timespan.
+	if err := qry.TimeSpan.Validate(); err != nil {
+		return api.InvalidRequestURL(err)
 	}
 
 	// Fetch data from the datastore.

--- a/cmd/openfish/services/annotations_test.go
+++ b/cmd/openfish/services/annotations_test.go
@@ -38,7 +38,12 @@ import (
 
 	"github.com/ausocean/openfish/cmd/openfish/entities"
 	"github.com/ausocean/openfish/cmd/openfish/services"
+	"github.com/ausocean/openfish/cmd/openfish/types/videotime"
 )
+
+// Constants
+var oneSec, _ = videotime.Parse("00:00:01")
+var oneMin, _ = videotime.Parse("00:01:00")
 
 func TestCreateAnnotation(t *testing.T) {
 	setup()
@@ -47,7 +52,7 @@ func TestCreateAnnotation(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	_, err := services.CreateAnnotation(vs,
-		entities.TimeSpan{Start: _8am, End: _9am},
+		entities.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 
@@ -63,7 +68,7 @@ func TestAnnotationExists(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	id, _ := services.CreateAnnotation(vs,
-		entities.TimeSpan{Start: _8am, End: _9am},
+		entities.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 
@@ -90,7 +95,7 @@ func TestGetAnnotationByID(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	id, _ := services.CreateAnnotation(vs,
-		entities.TimeSpan{Start: _8am, End: _9am},
+		entities.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 
@@ -98,7 +103,7 @@ func TestGetAnnotationByID(t *testing.T) {
 	if err != nil {
 		t.Errorf("Could not get annotation entity %s", err)
 	}
-	if annotation.VideoStreamID != vs || !annotation.TimeSpan.Start.Equal(_8am) || !annotation.TimeSpan.End.Equal(_9am) || annotation.BoundingBox != nil || annotation.Observer != "scott@ausocean.org" || annotation.ObservationKeys[0] != "species" || annotation.ObservationPairs[0] != "species:Sepia Apama" {
+	if annotation.VideoStreamID != vs || annotation.BoundingBox != nil || annotation.Observer != "scott@ausocean.org" || annotation.ObservationKeys[0] != "species" || annotation.ObservationPairs[0] != "species:Sepia Apama" {
 		t.Errorf("Annotation entity does not match created entity")
 	}
 }
@@ -121,7 +126,7 @@ func TestDeleteAnnotation(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	id, _ := services.CreateAnnotation(vs,
-		entities.TimeSpan{Start: _8am, End: _9am},
+		entities.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 

--- a/cmd/openfish/services/videostream_test.go
+++ b/cmd/openfish/services/videostream_test.go
@@ -205,7 +205,7 @@ func TestDeleteVideoStreamWithAssociatedAnnotations(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	id, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	services.CreateAnnotation(id,
-		entities.TimeSpan{Start: _8am, End: _9am},
+		entities.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 

--- a/cmd/openfish/types/videotime/videotime.go
+++ b/cmd/openfish/types/videotime/videotime.go
@@ -1,0 +1,108 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// videotime provides a type VideoTime that represents the time in a video - hours, minutes and seconds.
+// Unlike the time package, there is no concept of dates, and no timezones. VideoTimes are displayed in
+// the format 12:01:04, and can be serialized/deserialized to and from JSON in this format also.
+package videotime
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// VideoTime is a time in hours, minutes and seconds.
+type VideoTime struct {
+	value int64
+}
+
+// String converts a VideoTime to a string.
+func (t VideoTime) String() string {
+	// Seconds are what remain.
+	s := t.value
+
+	// Calculate hours.
+	h := s / (60 * 60)
+	s -= h * (60 * 60)
+
+	// Calculate minutes.
+	m := s / 60
+	s -= m * 60
+
+	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
+}
+
+// Parse converts a string to a VideoTime, or throws an error.
+func Parse(s string) (VideoTime, error) {
+	// Split on colons.
+	str := strings.Split(s, ":")
+	if len(str) != 3 {
+		return VideoTime{}, fmt.Errorf("invalid format: %s, must have three parts: hh:mm:ss", s)
+	}
+
+	// Parse as integers.
+	var nums [3]int
+	var err error
+	for i := 0; i < 3; i++ {
+		nums[i], err = strconv.Atoi(str[i])
+		if err != nil {
+			return VideoTime{}, fmt.Errorf("invalid format: %s, must only have numbers between ':' separator", s)
+		}
+	}
+
+	return New(nums[0], nums[1], nums[2])
+}
+
+// New creates a new VideoTime.
+func New(h int, m int, s int) (VideoTime, error) {
+	if s < 0 || s >= 60 {
+		return VideoTime{}, fmt.Errorf("invalid value, seconds is not 0 ≤ %d ≤ 59", s)
+	}
+	if m < 0 || m >= 60 {
+		return VideoTime{}, fmt.Errorf("invalid value, minutes is not 0 ≤ %d ≤ 59", m)
+	}
+	return VideoTime{value: int64(h*60*60 + m*60 + s)}, nil
+}
+
+// UnmarshalText is used for decoding query params or JSON into a VideoTime.
+func (t *VideoTime) UnmarshalText(text []byte) error {
+	var err error
+	*t, err = Parse(string(text))
+	return err
+}
+
+// MarshalText is used for encoding a VideoTime into JSON or query params.
+func (t VideoTime) MarshalText() ([]byte, error) {
+	return []byte(t.String()), nil
+}

--- a/cmd/openfish/types/videotime/videotime_test.go
+++ b/cmd/openfish/types/videotime/videotime_test.go
@@ -1,0 +1,93 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+package videotime_test
+
+import (
+	"testing"
+
+	"github.com/ausocean/openfish/cmd/openfish/types/videotime"
+)
+
+func TestString(t *testing.T) {
+	vt, _ := videotime.New(12, 34, 56)
+	expected := "12:34:56"
+
+	if vt.String() != expected {
+		t.Errorf("Expected %s, but got %s", expected, vt.String())
+	}
+}
+
+func TestParse(t *testing.T) {
+	str := "12:34:56"
+	expected, _ := videotime.New(12, 34, 56)
+
+	vt, err := videotime.Parse(str)
+	if err != nil {
+		t.Errorf("Error parsing time: %v", err)
+	}
+
+	if vt != expected {
+		t.Errorf("Expected value %s, but got %s", expected.String(), vt.String())
+	}
+}
+
+func TestUnmarshalText(t *testing.T) {
+	str := "12:34:56"
+	expected, _ := videotime.New(12, 34, 56)
+
+	vt := videotime.VideoTime{}
+
+	err := vt.UnmarshalText([]byte(str))
+	if err != nil {
+		t.Errorf("Error unmarshalling text: %v", err)
+	}
+
+	if vt != expected {
+		t.Errorf("Expected value %s, but got %s", expected.String(), vt.String())
+	}
+}
+
+func TestMarshalText(t *testing.T) {
+	vt, _ := videotime.New(12, 34, 56)
+	expected := "12:34:56"
+
+	data, err := vt.MarshalText()
+	if err != nil {
+		t.Errorf("Error marshalling text: %v", err)
+	}
+
+	if string(data) != expected {
+		t.Errorf("Expected text %s, but got %s", expected, string(data))
+	}
+}


### PR DESCRIPTION
Closes issue #113.

In many of our APIs we use timestamps to specify moments in a video. This is calculated as start timestamp + time elapsed. This was a mistake, as we are needlessly converting times backwards and forwards. It would be much easier to store the video time (e.g. 01:03:22.500) rather than ISO 8601 timestamp (2024-03-03T09:03:22.500Z).

This PR adds a new type - videotime which unlike time.Time does not have a date component or timezones. 

Note, changes to the frontend will be needed too, that is another PR