### PR TITLE
Time-spans are stored in datastore correctly

### DIFF
--- a/cmd/openfish/entities/annotations.go
+++ b/cmd/openfish/entities/annotations.go
@@ -37,24 +37,12 @@ package entities
 import (
 	"encoding/json"
 
-	"github.com/ausocean/openfish/cmd/openfish/types/videotime"
+	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 	"github.com/ausocean/openfish/datastore"
 )
 
 // Kind of entity to store / fetch from the datastore.
 const ANNOTATION_KIND = "Annotation"
-
-// TimeSpan is a pair of video timestamps - start time and end time.
-type TimeSpan struct {
-	Start videotime.VideoTime `json:"start"`
-	End   videotime.VideoTime `json:"end"`
-}
-
-// Validate tests that the start time occurs before the end time.
-func (t TimeSpan) Validate() error {
-	// TODO: Implement timespan validation.
-	return nil
-}
 
 // BoundingBox is a rectangle enclosing something interesting in a video.
 // It is represented using two x y coordinates, top left corner and bottom right corner of the rectangle.
@@ -68,7 +56,7 @@ type BoundingBox struct {
 // An Annotation holds information about observations at a particular moment and region within a video stream.
 type Annotation struct {
 	VideoStreamID    int64
-	TimeSpan         TimeSpan
+	TimeSpan         timespan.TimeSpan
 	BoundingBox      *BoundingBox // Optional.
 	Observer         string
 	ObservationPairs []string

--- a/cmd/openfish/handlers/annotations.go
+++ b/cmd/openfish/handlers/annotations.go
@@ -43,6 +43,7 @@ import (
 	"github.com/ausocean/openfish/cmd/openfish/api"
 	"github.com/ausocean/openfish/cmd/openfish/entities"
 	"github.com/ausocean/openfish/cmd/openfish/services"
+	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -52,7 +53,7 @@ import (
 type AnnotationResult struct {
 	ID            *int64                `json:"id,omitempty"`
 	VideoStreamID *int64                `json:"videostreamId,omitempty"`
-	TimeSpan      *entities.TimeSpan    `json:"timespan,omitempty"`
+	TimeSpan      *timespan.TimeSpan    `json:"timespan,omitempty"`
 	BoundingBox   *entities.BoundingBox `json:"boundingBox,omitempty"`
 	Observer      *string               `json:"observer,omitempty"`
 	Observation   map[string]string     `json:"observation,omitempty"`
@@ -104,7 +105,7 @@ type GetAnnotationsQuery struct {
 // BoundingBox is optional because some annotations might not be described by a rectangular area.
 type CreateAnnotationBody struct {
 	VideoStreamID int64                 `json:"videostreamId"`
-	TimeSpan      entities.TimeSpan     `json:"timespan"`
+	TimeSpan      timespan.TimeSpan     `json:"timespan"`
 	BoundingBox   *entities.BoundingBox `json:"boundingBox"` // Optional.
 	Observer      string                `json:"observer"`
 	Observation   map[string]string     `json:"observation"`

--- a/cmd/openfish/handlers/videostream.go
+++ b/cmd/openfish/handlers/videostream.go
@@ -35,12 +35,14 @@ LICENSE
 package handlers
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/ausocean/openfish/cmd/openfish/api"
 	"github.com/ausocean/openfish/cmd/openfish/entities"
 	"github.com/ausocean/openfish/cmd/openfish/services"
+	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -83,7 +85,7 @@ func FromVideoStream(videoStream *entities.VideoStream, id int64, format *api.Fo
 // GetVideoStreamsQuery describes the URL query parameters required for the GetVideoStreams endpoint.
 type GetVideoStreamsQuery struct {
 	CaptureSource *int64             `query:"capturesource"` // Optional.
-	TimeSpan      *entities.TimeSpan `query:"timespan"`      // Optional.
+	TimeSpan      *timespan.TimeSpan `query:"timespan"`      // Optional.
 	api.LimitAndOffset
 }
 
@@ -159,8 +161,10 @@ func GetVideoStreams(ctx *fiber.Ctx) error {
 	}
 
 	// Validate timespan.
-	if err := qry.TimeSpan.Validate(); err != nil {
-		return api.InvalidRequestURL(err)
+	if qry.TimeSpan != nil {
+		if !qry.TimeSpan.Valid() {
+			return api.InvalidRequestURL(fmt.Errorf("invalid time span, start time must occur before end time"))
+		}
 	}
 
 	// Fetch data from the datastore.

--- a/cmd/openfish/services/annotations.go
+++ b/cmd/openfish/services/annotations.go
@@ -41,6 +41,7 @@ import (
 
 	"github.com/ausocean/openfish/cmd/openfish/ds_client"
 	"github.com/ausocean/openfish/cmd/openfish/entities"
+	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 	"github.com/ausocean/openfish/datastore"
 )
 
@@ -102,7 +103,7 @@ func GetAnnotations(limit int, offset int, observer *string, observation map[str
 }
 
 // CreateAnnotation creates a new annotation.
-func CreateAnnotation(videoStreamID int64, timeSpan entities.TimeSpan, boundingBox *entities.BoundingBox, observer string, observation map[string]string) (int64, error) {
+func CreateAnnotation(videoStreamID int64, timeSpan timespan.TimeSpan, boundingBox *entities.BoundingBox, observer string, observation map[string]string) (int64, error) {
 	// Convert observation map into a format the datastore can take.
 	obsKeys := make([]string, 0, len(observation))
 	obsPairs := make([]string, 0, len(observation))

--- a/cmd/openfish/services/annotations_test.go
+++ b/cmd/openfish/services/annotations_test.go
@@ -36,8 +36,8 @@ package services_test
 import (
 	"testing"
 
-	"github.com/ausocean/openfish/cmd/openfish/entities"
 	"github.com/ausocean/openfish/cmd/openfish/services"
+	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 	"github.com/ausocean/openfish/cmd/openfish/types/videotime"
 )
 
@@ -52,7 +52,7 @@ func TestCreateAnnotation(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	_, err := services.CreateAnnotation(vs,
-		entities.TimeSpan{Start: oneSec, End: oneMin},
+		timespan.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 
@@ -68,7 +68,7 @@ func TestAnnotationExists(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	id, _ := services.CreateAnnotation(vs,
-		entities.TimeSpan{Start: oneSec, End: oneMin},
+		timespan.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 
@@ -95,7 +95,7 @@ func TestGetAnnotationByID(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	id, _ := services.CreateAnnotation(vs,
-		entities.TimeSpan{Start: oneSec, End: oneMin},
+		timespan.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 
@@ -126,7 +126,7 @@ func TestDeleteAnnotation(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	id, _ := services.CreateAnnotation(vs,
-		entities.TimeSpan{Start: oneSec, End: oneMin},
+		timespan.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 

--- a/cmd/openfish/services/videostream.go
+++ b/cmd/openfish/services/videostream.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/ausocean/openfish/cmd/openfish/ds_client"
 	"github.com/ausocean/openfish/cmd/openfish/entities"
+	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 	"github.com/ausocean/openfish/datastore"
 )
 
@@ -65,7 +66,7 @@ func VideoStreamExists(id int64) bool {
 }
 
 // GetVideoStreams gets a list of video streams, filtering by timespan, capturesource if specified.
-func GetVideoStreams(limit int, offset int, timespan *entities.TimeSpan, captureSource *int64) ([]entities.VideoStream, []int64, error) {
+func GetVideoStreams(limit int, offset int, timespan *timespan.TimeSpan, captureSource *int64) ([]entities.VideoStream, []int64, error) {
 	// Fetch data from the datastore.
 	store := ds_client.Get()
 	query := store.NewQuery(entities.VIDEOSTREAM_KIND, false)

--- a/cmd/openfish/services/videostream_test.go
+++ b/cmd/openfish/services/videostream_test.go
@@ -37,8 +37,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ausocean/openfish/cmd/openfish/entities"
 	"github.com/ausocean/openfish/cmd/openfish/services"
+	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 )
 
 // Constants.
@@ -205,7 +205,7 @@ func TestDeleteVideoStreamWithAssociatedAnnotations(t *testing.T) {
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	id, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	services.CreateAnnotation(id,
-		entities.TimeSpan{Start: oneSec, End: oneMin},
+		timespan.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
 		map[string]string{"species": "Sepia Apama"})
 

--- a/cmd/openfish/types/timespan/timespan.go
+++ b/cmd/openfish/types/timespan/timespan.go
@@ -1,0 +1,86 @@
+/*
+AUTHORS
+  Scott Barnard <scott@ausocean.org>
+
+LICENSE
+  Copyright (c) 2023-2024, The OpenFish Contributors.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions are met:
+
+  1. Redistributions of source code must retain the above copyright notice, this
+     list of conditions and the following disclaimer.
+
+  2. Redistributions in binary form must reproduce the above copyright notice,
+     this list of conditions and the following disclaimer in the documentation
+     and/or other materials provided with the distribution.
+
+  3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+     nor the names of its contributors may be used to endorse or promote
+     products derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+// Timespan struct represents a start and end time in a video.
+// Uses a custom Save and Load method for reading/writing to the datastore.
+// TODO: add timespan validation to type (end > start).
+package timespan
+
+import (
+	googlestore "cloud.google.com/go/datastore"
+
+	"github.com/ausocean/openfish/cmd/openfish/types/videotime"
+	"github.com/ausocean/openfish/datastore"
+)
+
+// TimeSpan is a pair of video timestamps - start time and end time.
+type TimeSpan struct {
+	Start videotime.VideoTime `json:"start"`
+	End   videotime.VideoTime `json:"end"`
+}
+
+// Valid tests if a timespan is valid. Start should be less than End.
+func (t TimeSpan) Valid() bool {
+	return t.Start.Int() <= t.End.Int()
+}
+
+// Load implements loading from the datastore.
+func (t *TimeSpan) Load(ps []datastore.Property) error {
+	var data struct {
+		Start string
+		End   string
+	}
+
+	if err := googlestore.LoadStruct(&data, ps); err != nil {
+		return err
+	}
+
+	t.Start, _ = videotime.Parse(data.Start)
+	t.End, _ = videotime.Parse(data.End)
+
+	return nil
+}
+
+// Save implements saving to the datastore.
+func (t *TimeSpan) Save() ([]datastore.Property, error) {
+	return []datastore.Property{
+		{
+			Name:  "Start",
+			Value: t.Start.String(),
+		},
+		{
+			Name:  "End",
+			Value: t.End.String(),
+		},
+	}, nil
+}

--- a/cmd/openfish/types/videotime/videotime.go
+++ b/cmd/openfish/types/videotime/videotime.go
@@ -63,6 +63,11 @@ func (t VideoTime) String() string {
 	return fmt.Sprintf("%02d:%02d:%02d", h, m, s)
 }
 
+// Int converts a VideoTime to an int64 (seconds).
+func (t VideoTime) Int() int64 {
+	return t.value
+}
+
 // Parse converts a string to a VideoTime, or throws an error.
 func Parse(s string) (VideoTime, error) {
 	// Split on colons.


### PR DESCRIPTION
After changing away from time.Time for video times, timespans are now not being stored in the datastore. This adds a Load and Save method to timespan to fix this bug.