### PR TITLE
Fix deployment to Google AppEngine

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -7,7 +7,7 @@
 # Go code.
 !go.mod
 !go.sum
-!api/
+!cmd/
 !datastore/
 
 

--- a/app.yaml
+++ b/app.yaml
@@ -6,7 +6,7 @@ env_variables:
   FILESTORE: 'false'
   JWT_AUDIENCE: '/projects/174291483773/apps/openfish'
 
-main: ./api/main.go
+main: ./cmd/openfish/main.go
 
 handlers:
 


### PR DESCRIPTION
Deployment was broken because of renaming of a directory to `cmd/openfish`