### PR TITLE
Use times in format hh:mm:ss on client

### DIFF
--- a/openfish-webapp/src/utils/api.types.ts
+++ b/openfish-webapp/src/utils/api.types.ts
@@ -27,9 +27,11 @@ export interface Observation {
   [key: string]: string
 }
 
+export type VideoTime = `${number}:${number}:${number}`
+
 export interface Timespan {
-  start: Date | string
-  end: Date | string
+  start: VideoTime
+  end: VideoTime
 }
 
 export interface BoundingBox {

--- a/openfish-webapp/src/utils/datetime.ts
+++ b/openfish-webapp/src/utils/datetime.ts
@@ -1,14 +1,4 @@
-// Convert a video time in seconds to a datetime.
-export function videotimeToDatetime(streamStart: string, time: number): Date {
-  const playbackDatetime = new Date(streamStart)
-  playbackDatetime.setSeconds(playbackDatetime.getSeconds() + time)
-  return playbackDatetime
-}
-
-// Convert a datetime to a video time in seconds.
-export function datetimeToVideoTime(streamStart: DateLike, datetime: DateLike): number {
-  return (new Date(datetime).getTime() - new Date(streamStart).getTime()) / 1000
-}
+import type { VideoTime } from './api.types'
 
 // Subtracts datetimes and returns difference as a number in seconds.
 export function datetimeDifference(a: DateLike, b: DateLike): number {
@@ -53,15 +43,20 @@ export function formatAsTimeZone(dt: DateLike): string {
     .slice(4)
 }
 
-export function formatDuration(duration: number): string {
-  const h = Math.floor(duration / 3600)
-  const m = Math.floor((duration - h * 3600) / 60)
-  const s = duration - h * 3600 - m * 60
+export function formatDuration(seconds: number): string {
+  const h = Math.floor(seconds / 3600)
+  const m = Math.floor((seconds - h * 3600) / 60)
+  const s = seconds - h * 3600 - m * 60
   return `${h}h ${m}m ${s}s `
 }
 
-export function formatVideoTime(seconds: number): string {
+export function formatVideoTime(seconds: number): VideoTime {
   const date = new Date(0)
   date.setSeconds(seconds)
-  return date.toISOString().substring(11, 19)
+  return date.toISOString().substring(11, 19) as VideoTime
+}
+
+export function parseVideoTime(str: VideoTime): number {
+  const [h, m, s] = str.split(':')
+  return Number(h) * 60 * 60 + Number(m) * 60 + Number(s)
 }

--- a/openfish-webapp/src/webcomponents/annotation-card.ts
+++ b/openfish-webapp/src/webcomponents/annotation-card.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import type { Annotation } from '../utils/api.types.ts'
 import { repeat } from 'lit/directives/repeat.js'
-import { formatAsDate, formatAsTime, formatAsTimeZone } from '../utils/datetime.ts'
+import { formatDuration, parseVideoTime } from '../utils/datetime.ts'
 
 /**
  * TODO: write component documentation
@@ -21,20 +21,9 @@ export class AnnotationCard extends LitElement {
       return html`<div class="card"></div>`
     }
 
-    const start = new Date(this.annotation.timespan.start)
-    const end = new Date(this.annotation.timespan.end)
-    const duration = (end.getTime() - start.getTime()) / 1000
-    const tz = formatAsTimeZone(start)
-
-    const startDate = formatAsDate(start)
-    const startTime = formatAsTime(start)
-    const endDate = formatAsDate(end)
-    const endTime = formatAsTime(end)
-
-    const rangeFormatted =
-      startDate === endDate
-        ? html`<em>${startDate}</em>, from <em>${startTime}</em> until <em>${endTime}</em>`
-        : html`From <em>${startDate}, ${startTime}</em> until <em>${endDate}, ${endTime}</em>`
+    const start = this.annotation.timespan.start
+    const end = this.annotation.timespan.end
+    const duration = formatDuration(parseVideoTime(end) - parseVideoTime(start))
 
     const rows = repeat(
       Object.entries(this.annotation.observation),
@@ -55,7 +44,7 @@ export class AnnotationCard extends LitElement {
     <div class="timestamps">
       <div>
         <span>Time: </span>
-        <span>${rangeFormatted} [${tz}]</span>
+        <span><em>${start}</em> - <em>${end}</em></span>
       </div>
       <div>
         <span>Duration: </span>


### PR DESCRIPTION
This updates the client to handle video times using the hh:mm:ss format, matching the API