### PR TITLE
Skip importing species if they do not have a photo

### DIFF
--- a/cmd/openfish/handlers/species.go
+++ b/cmd/openfish/handlers/species.go
@@ -198,6 +198,10 @@ func ImportFromINaturalist(ctx *fiber.Ctx) error {
 
 		// Insert species into datastore or update existing entry.
 		for _, s := range species {
+			// Skip species without a photo.
+			if s.DefaultPhoto == nil {
+				continue
+			}
 
 			img := entities.Image{Src: s.DefaultPhoto.MediumURL, Attribution: s.DefaultPhoto.Attribution}
 

--- a/cmd/openfish/services/inaturalist_taxa.go
+++ b/cmd/openfish/services/inaturalist_taxa.go
@@ -60,7 +60,7 @@ type Taxa struct {
 	Ancestry                  string     `json:"ancestry"`
 	Names                     []Name     `json:"names"`
 	Extinct                   bool       `json:"extinct"`
-	DefaultPhoto              Photo      `json:"default_photo"`
+	DefaultPhoto              *Photo     `json:"default_photo"`
 	TaxonChangesCount         int        `json:"taxon_changes_count"`
 	TaxonSchemesCount         int        `json:"taxon_schemes_count"`
 	ObservationsCount         int        `json:"observations_count"`


### PR DESCRIPTION
A lot of the species in iNaturalist do not have photos. Users of openfish may have difficulty making correct identifications without a reference picture so it is probably best if we just skip these and don't import them. I have gone and deleted the existing ones missing pictures from the datastore.