### PR TITLE
Add a default implementation for encode/decode

### DIFF
--- a/cmd/openfish/entities/annotations.go
+++ b/cmd/openfish/entities/annotations.go
@@ -35,8 +35,6 @@ LICENSE
 package entities
 
 import (
-	"encoding/json"
-
 	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 	"github.com/ausocean/openfish/datastore"
 )
@@ -61,17 +59,6 @@ type Annotation struct {
 	Observer         string
 	ObservationPairs []string
 	ObservationKeys  []string // A copy of the map's keys are stored separately, so we can quickly query for annotations with a given key present.
-}
-
-// Encode serializes Annotation. Implements Entity interface. Used for FileStore datastore.
-func (an *Annotation) Encode() []byte {
-	bytes, _ := json.Marshal(an)
-	return bytes
-}
-
-// Encode deserializes Annotation. Implements Entity interface. Used for FileStore datastore.
-func (an *Annotation) Decode(b []byte) error {
-	return json.Unmarshal(b, an)
 }
 
 // Implements Copy from the Entity interface.

--- a/cmd/openfish/entities/capturesource.go
+++ b/cmd/openfish/entities/capturesource.go
@@ -35,8 +35,6 @@ LICENSE
 package entities
 
 import (
-	"encoding/json"
-
 	googlestore "cloud.google.com/go/datastore"
 
 	"github.com/ausocean/openfish/datastore"
@@ -52,17 +50,6 @@ type CaptureSource struct {
 	Location       googlestore.GeoPoint
 	CameraHardware string
 	SiteID         *int64 // Optional.
-}
-
-// Encode serializes Capture source. Implements Entity interface. Used for FileStore datastore.
-func (cs *CaptureSource) Encode() []byte {
-	bytes, _ := json.Marshal(cs)
-	return bytes
-}
-
-// Encode deserializes Capture source. Implements Entity interface. Used for FileStore datastore.
-func (cs *CaptureSource) Decode(b []byte) error {
-	return json.Unmarshal(b, cs)
 }
 
 // Implements Copy from the Entity interface.

--- a/cmd/openfish/entities/species.go
+++ b/cmd/openfish/entities/species.go
@@ -34,8 +34,6 @@ LICENSE
 package entities
 
 import (
-	"encoding/json"
-
 	"github.com/ausocean/openfish/datastore"
 )
 
@@ -53,17 +51,6 @@ type Species struct {
 type Image struct {
 	Src         string `json:"src"`
 	Attribution string `json:"attribution"`
-}
-
-// Encode serializes Species. Implements Entity interface. Used for FileStore datastore.
-func (vs *Species) Encode() []byte {
-	bytes, _ := json.Marshal(vs)
-	return bytes
-}
-
-// Encode deserializes Species. Implements Entity interface. Used for FileStore datastore.
-func (vs *Species) Decode(b []byte) error {
-	return json.Unmarshal(b, vs)
 }
 
 // Implements Copy from the Entity interface.

--- a/cmd/openfish/entities/users.go
+++ b/cmd/openfish/entities/users.go
@@ -34,7 +34,6 @@ LICENSE
 package entities
 
 import (
-	"encoding/json"
 	"fmt"
 
 	"github.com/ausocean/openfish/datastore"
@@ -88,17 +87,6 @@ func ParseRole(s string) (Role, error) {
 		return AdminRole, nil
 	}
 	return DefaultRole, fmt.Errorf("invalid role provided: %s", s)
-}
-
-// Encode serializes User. Implements Entity interface. Used for FileStore datastore.
-func (vs *User) Encode() []byte {
-	bytes, _ := json.Marshal(vs)
-	return bytes
-}
-
-// Encode deserializes User. Implements Entity interface. Used for FileStore datastore.
-func (vs *User) Decode(b []byte) error {
-	return json.Unmarshal(b, vs)
 }
 
 // Implements Copy from the Entity interface.

--- a/cmd/openfish/entities/videostream.go
+++ b/cmd/openfish/entities/videostream.go
@@ -34,7 +34,6 @@ LICENSE
 package entities
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/ausocean/openfish/datastore"
@@ -52,17 +51,6 @@ type VideoStream struct {
 	StreamUrl     string
 	CaptureSource int64
 	AnnotatorList []string
-}
-
-// Encode serializes VideoStream. Implements Entity interface. Used for FileStore datastore.
-func (vs *VideoStream) Encode() []byte {
-	bytes, _ := json.Marshal(vs)
-	return bytes
-}
-
-// Encode deserializes VideoStream. Implements Entity interface. Used for FileStore datastore.
-func (vs *VideoStream) Decode(b []byte) error {
-	return json.Unmarshal(b, vs)
 }
 
 // Implements Copy from the Entity interface.


### PR DESCRIPTION
Closes issue https://github.com/ausocean/openfish/issues/3

Adds a default implementation for encoding/decoding entities using JSON marshal / unmarshal. 

If you want to have custom implementations for encode and decode, you can implement the EntityEncoder interface (Encode method) and the EntityDecoder interface (Decode method)

Changes are backwards compatible and should not require any changes to consuming code.