### PR TITLE
Limit annotations to known species in our datastore

### DIFF
--- a/cmd/openfish/ds_client/ds_client.go
+++ b/cmd/openfish/ds_client/ds_client.go
@@ -64,4 +64,6 @@ func Init(local bool) {
 	datastore.RegisterEntity(entities.CAPTURESOURCE_KIND, entities.NewCaptureSource)
 	datastore.RegisterEntity(entities.VIDEOSTREAM_KIND, entities.NewVideoStream)
 	datastore.RegisterEntity(entities.ANNOTATION_KIND, entities.NewAnnotation)
+	datastore.RegisterEntity(entities.SPECIES_KIND, entities.NewSpecies)
+	datastore.RegisterEntity(entities.USER_KIND, entities.NewUser)
 }

--- a/cmd/openfish/services/annotations_test.go
+++ b/cmd/openfish/services/annotations_test.go
@@ -36,6 +36,7 @@ package services_test
 import (
 	"testing"
 
+	"github.com/ausocean/openfish/cmd/openfish/entities"
 	"github.com/ausocean/openfish/cmd/openfish/services"
 	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 	"github.com/ausocean/openfish/cmd/openfish/types/videotime"
@@ -49,12 +50,13 @@ func TestCreateAnnotation(t *testing.T) {
 	setup()
 
 	// Create a new annotation entity.
+	services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0), nil)
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	_, err := services.CreateAnnotation(vs,
 		timespan.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
-		map[string]string{"species": "Sepia Apama"})
+		map[string]string{"species": "Sepioteuthis australis", "common_name": "Southern Reef Squid"})
 
 	if err != nil {
 		t.Errorf("Could not create annotation entity %s", err)
@@ -65,12 +67,13 @@ func TestAnnotationExists(t *testing.T) {
 	setup()
 
 	// Create a new annotation entity.
+	services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0), nil)
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	id, _ := services.CreateAnnotation(vs,
 		timespan.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
-		map[string]string{"species": "Sepia Apama"})
+		map[string]string{"species": "Sepioteuthis australis", "common_name": "Southern Reef Squid"})
 
 	// Check if the annotation exists.
 	if !services.AnnotationExists(int64(id)) {
@@ -92,18 +95,19 @@ func TestGetAnnotationByID(t *testing.T) {
 	setup()
 
 	// Create a new annotation entity.
+	services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0), nil)
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	id, _ := services.CreateAnnotation(vs,
 		timespan.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
-		map[string]string{"species": "Sepia Apama"})
+		map[string]string{"species": "Sepioteuthis australis", "common_name": "Southern Reef Squid"})
 
 	annotation, err := services.GetAnnotationByID(int64(id))
 	if err != nil {
 		t.Errorf("Could not get annotation entity %s", err)
 	}
-	if annotation.VideoStreamID != vs || annotation.BoundingBox != nil || annotation.Observer != "scott@ausocean.org" || annotation.ObservationKeys[0] != "species" || annotation.ObservationPairs[0] != "species:Sepia Apama" {
+	if annotation.VideoStreamID != vs || annotation.BoundingBox != nil || annotation.Observer != "scott@ausocean.org" {
 		t.Errorf("Annotation entity does not match created entity")
 	}
 }
@@ -123,12 +127,13 @@ func TestDeleteAnnotation(t *testing.T) {
 	setup()
 
 	// Create a new annotation entity.
+	services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0), nil)
 	cs, _ := services.CreateCaptureSource("Stony Point camera 1", 0.0, 0.0, "RPI camera", nil)
 	vs, _ := services.CreateVideoStream("http://youtube.com/watch?v=abc123", int64(cs), _8am, &_4pm, []string{})
 	id, _ := services.CreateAnnotation(vs,
 		timespan.TimeSpan{Start: oneSec, End: oneMin},
 		nil, "scott@ausocean.org",
-		map[string]string{"species": "Sepia Apama"})
+		map[string]string{"species": "Sepioteuthis australis", "common_name": "Southern Reef Squid"})
 
 	// Delete the annotation entity.
 	err := services.DeleteAnnotation(int64(id))

--- a/cmd/openfish/services/species.go
+++ b/cmd/openfish/services/species.go
@@ -75,6 +75,27 @@ func GetSpeciesByINaturalistID(id int) (*entities.Species, int64, error) {
 	return &species[0], keys[0].ID, nil
 }
 
+// GetSpeciesByINaturalist gets a species when provided with its scientific name.
+func GetSpeciesByScientificName(name string) (*entities.Species, int64, error) {
+	store := ds_client.Get()
+	query := store.NewQuery(entities.SPECIES_KIND, false)
+
+	query.FilterField("Species", "=", name)
+	query.Limit(1)
+
+	var species []entities.Species
+	keys, err := store.GetAll(context.Background(), query, &species)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if len(keys) == 0 {
+		return nil, 0, nil
+	}
+
+	return &species[0], keys[0].ID, nil
+}
+
 func SpeciesExists(id int64) bool {
 	store := ds_client.Get()
 	key := store.IDKey(entities.SPECIES_KIND, id)

--- a/cmd/openfish/services/species_test.go
+++ b/cmd/openfish/services/species_test.go
@@ -87,6 +87,21 @@ func TestGetSpeciesByID(t *testing.T) {
 	}
 }
 
+func TestGetSpeciesByScientificName(t *testing.T) {
+	setup()
+
+	// Create a new species entity.
+	services.CreateSpecies("Sepioteuthis australis", "Southern Reef Squid", make([]entities.Image, 0), nil)
+
+	species, _, err := services.GetSpeciesByScientificName("Sepioteuthis australis")
+	if err != nil {
+		t.Errorf("Could not get species entity %s", err)
+	}
+	if species.CommonName != "Southern Reef Squid" && species.Species != "Sepioteuthis australis" && len(species.Images) != 0 {
+		t.Errorf("Video stream entity does not match created entity")
+	}
+}
+
 func TestGetSpeciesByIDForNonexistentEntity(t *testing.T) {
 	setup()
 


### PR DESCRIPTION
Adds validation to observations to check that the species exists in our datastore.