### PR TITLE
Use github reporter in CI & update actions

### DIFF
--- a/.github/workflows/code-checks.yaml
+++ b/.github/workflows/code-checks.yaml
@@ -6,7 +6,7 @@ jobs:
   api:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Go
       uses: actions/setup-go@v4
@@ -25,9 +25,9 @@ jobs:
   webapp:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 20
 
@@ -40,10 +40,10 @@ jobs:
       run: pnpm --filter ./openfish-webapp build
     
     - name: Check formatting
-      run: pnpm --filter ./openfish-webapp ci:check
-
-    - name: Lint
       run: pnpm --filter ./openfish-webapp ci:fmt
 
+    - name: Lint
+      run: pnpm --filter ./openfish-webapp ci:check
+
     - name: Test
-      run: pnpm --filter ./openfish-webapp test
+      run: pnpm --filter ./openfish-webapp ci:test

--- a/.github/workflows/deploy-documentation.yaml
+++ b/.github/workflows/deploy-documentation.yaml
@@ -26,10 +26,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/.github/workflows/deploy-openfish.yaml
+++ b/.github/workflows/deploy-openfish.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 20
 

--- a/openfish-webapp/package.json
+++ b/openfish-webapp/package.json
@@ -8,9 +8,10 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "fmt": "biome format . --write",
-    "check": "biome check .",
+    "check": "biome check . --write",
     "test": "vitest run --passWithNoTests",
-    "ci:fmt": "biome ci --formatter-enabled=true .",
-    "ci:check": "biome ci --linter-enabled=true ."
+    "ci:test": "vitest run --passWithNoTests --reporter=github-actions",
+    "ci:fmt": "biome ci --formatter-enabled=true --reporter=github .",
+    "ci:check": "biome ci --linter-enabled=true --reporter=github ."
   }
 }


### PR DESCRIPTION
Using github actions reporters means the CI errors will show up in github's UI.

Actions have been updated because they use an older version of node and it is displaying a warning