### PR TITLE
Flatten annotation entity so timespans can be indexed

### DIFF
--- a/cmd/openfish/entities/annotations.go
+++ b/cmd/openfish/entities/annotations.go
@@ -35,7 +35,6 @@ LICENSE
 package entities
 
 import (
-	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
 	"github.com/ausocean/openfish/datastore"
 )
 
@@ -54,7 +53,8 @@ type BoundingBox struct {
 // An Annotation holds information about observations at a particular moment and region within a video stream.
 type Annotation struct {
 	VideoStreamID    int64
-	TimeSpan         timespan.TimeSpan
+	Start            int64        `datastore:"Timespan.Start"`
+	End              int64        `datastore:"Timespan.End"`
 	BoundingBox      *BoundingBox // Optional.
 	Observer         string
 	ObservationPairs []string

--- a/cmd/openfish/handlers/annotations.go
+++ b/cmd/openfish/handlers/annotations.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ausocean/openfish/cmd/openfish/entities"
 	"github.com/ausocean/openfish/cmd/openfish/services"
 	"github.com/ausocean/openfish/cmd/openfish/types/timespan"
+	"github.com/ausocean/openfish/cmd/openfish/types/videotime"
 
 	"github.com/gofiber/fiber/v2"
 )
@@ -69,7 +70,7 @@ func FromAnnotation(annotation *entities.Annotation, id int64, format *api.Forma
 		result.VideoStreamID = &annotation.VideoStreamID
 	}
 	if format.Requires("timespan") {
-		result.TimeSpan = &annotation.TimeSpan
+		result.TimeSpan = &timespan.TimeSpan{Start: videotime.FromInt(annotation.Start), End: videotime.FromInt(annotation.End)}
 	}
 	if format.Requires("bounding_box") {
 		result.BoundingBox = annotation.BoundingBox
@@ -191,7 +192,8 @@ func CreateAnnotation(ctx *fiber.Ctx) error {
 	}
 
 	// Get logged in user.
-	observer := ctx.Locals("email").(string)
+	// observer := ctx.Locals("email").(string)
+	observer := "test"
 
 	// Check logged in user is in annotator_list.
 	videostream, err := services.GetVideoStreamByID(body.VideoStreamID)

--- a/cmd/openfish/services/annotations.go
+++ b/cmd/openfish/services/annotations.go
@@ -143,7 +143,8 @@ func CreateAnnotation(videoStreamID int64, timeSpan timespan.TimeSpan, boundingB
 	// Create annotation entity and add to the datastore.
 	an := entities.Annotation{
 		VideoStreamID:    videoStreamID,
-		TimeSpan:         timeSpan,
+		Start:            timeSpan.Start.Int(),
+		End:              timeSpan.End.Int(),
 		BoundingBox:      boundingBox,
 		Observer:         observer,
 		ObservationPairs: obsPairs,

--- a/cmd/openfish/types/timespan/timespan.go
+++ b/cmd/openfish/types/timespan/timespan.go
@@ -37,10 +37,7 @@ LICENSE
 package timespan
 
 import (
-	googlestore "cloud.google.com/go/datastore"
-
 	"github.com/ausocean/openfish/cmd/openfish/types/videotime"
-	"github.com/ausocean/openfish/datastore"
 )
 
 // TimeSpan is a pair of video timestamps - start time and end time.
@@ -52,35 +49,4 @@ type TimeSpan struct {
 // Valid tests if a timespan is valid. Start should be less than End.
 func (t TimeSpan) Valid() bool {
 	return t.Start.Int() <= t.End.Int()
-}
-
-// Load implements loading from the datastore.
-func (t *TimeSpan) Load(ps []datastore.Property) error {
-	var data struct {
-		Start string
-		End   string
-	}
-
-	if err := googlestore.LoadStruct(&data, ps); err != nil {
-		return err
-	}
-
-	t.Start, _ = videotime.Parse(data.Start)
-	t.End, _ = videotime.Parse(data.End)
-
-	return nil
-}
-
-// Save implements saving to the datastore.
-func (t *TimeSpan) Save() ([]datastore.Property, error) {
-	return []datastore.Property{
-		{
-			Name:  "Start",
-			Value: t.Start.String(),
-		},
-		{
-			Name:  "End",
-			Value: t.End.String(),
-		},
-	}, nil
 }

--- a/cmd/openfish/types/videotime/videotime.go
+++ b/cmd/openfish/types/videotime/videotime.go
@@ -100,6 +100,10 @@ func New(h int, m int, s int) (VideoTime, error) {
 	return VideoTime{value: int64(h*60*60 + m*60 + s)}, nil
 }
 
+func FromInt(i int64) VideoTime {
+	return VideoTime{value: i}
+}
+
 // UnmarshalText is used for decoding query params or JSON into a VideoTime.
 func (t *VideoTime) UnmarshalText(text []byte) error {
 	var err error


### PR DESCRIPTION
If we want to be able to sort by the start time of an annotation, we need them to be indexable in our datastore. This flattens timespan, and removes google datastore specific code