### PR TITLE
Search-improvement

### DIFF
--- a/cmd/openfish/entities/species.go
+++ b/cmd/openfish/entities/species.go
@@ -46,6 +46,7 @@ type Species struct {
 	CommonName         string
 	Images             []Image
 	INaturalistTaxonID *int // Optional.
+	SearchIndex        []string
 }
 
 type Image struct {


### PR DESCRIPTION
Search queries are case insensitive: e.g. `wHal` matches `Whale Shark`

Search queries will now match not just the first word in a species' common name: e.g. `shar` matches `Whale Shark`

Search queries will now match on scientific names: e.g. `rhin` matches `Rhincodon typus`