### PR TITLE
Refactor capture sources page to use a generic data table component

### DIFF
--- a/openfish-webapp/capturesources.html
+++ b/openfish-webapp/capturesources.html
@@ -10,7 +10,7 @@
 
     <script type="module" src="./src/webcomponents/user-provider.ts"></script>
     <script type="module" src="./src/webcomponents/site-nav.ts"></script>
-    <script type="module" src="./src/webcomponents/capturesource-list.ts"></script>
+    <script type="module" src="./src/webcomponents/data-table.ts"></script>
     <script type="module" src="./src/webcomponents/confirm-dialog.ts"></script>
     <script type="module" src="./src/webcomponents/create-capture-source-dialog.ts"></script>
     
@@ -24,18 +24,16 @@
         display: flex;
         justify-content: space-between;
       }
-      capturesource-list {
+      data-table {
         grid-column: page;
       }
-
-
     </style>
 
     <script type="module" >
-    const list = document.querySelector("capturesource-list")
     const confirmDialog = document.querySelector("confirm-dialog")
     const createCaptureSourceDialog = document.querySelector("create-capture-source-dialog")
     const createBtn = document.querySelector("#create-btn")
+    // const dataTable = document.querySelector("data-table")
 
     async function deleteCaptureSource(id) {
       try {
@@ -48,7 +46,6 @@
       }
     }
 
-    list.addEventListener("deleteitem", (e) => confirmDialog.show(()=> deleteCaptureSource(e.detail)))
     createBtn.addEventListener("click", () => createCaptureSourceDialog.show())
     createCaptureSourceDialog.addEventListener("createitem", ()=>list.fetchData())
     </script>
@@ -61,7 +58,12 @@
         <button class="btn btn-blue" id="create-btn">+ Create new capture source</button>
       </header>
         
-      <capturesource-list></capturesource-list>
+      <data-table src="/api/v1/capturesources" colwidths="2fr 3fr 2fr 2fr">
+        <dt-col title="Name" key="name"></dt-col>
+        <dt-col title="Camera Hardware" key="camera_hardware"></dt-col>
+        <dt-col title="Site ID" key="site_id"></dt-col>
+        <dt-col title="Location" key="location"></dt-col>
+      </data-table>
 
       <confirm-dialog>Are you sure you want to delete this capture source?</confirm-dialog>
       <create-capture-source-dialog></create-capture-source-dialog>

--- a/openfish-webapp/src/webcomponents/data-table.ts
+++ b/openfish-webapp/src/webcomponents/data-table.ts
@@ -1,0 +1,196 @@
+import { LitElement, css, html, unsafeCSS } from 'lit'
+import { customElement, property, state } from 'lit/decorators.js'
+import resetcss from '../styles/reset.css?raw'
+import btncss from '../styles/buttons.css?raw'
+import { repeat } from 'lit/directives/repeat.js'
+import { provide, consume, createContext } from '@lit/context'
+
+export type ClickRowEvent<T> = CustomEvent<T>
+
+export type HoverItemEvent = CustomEvent<number | undefined>
+
+export const dataContext = createContext(Symbol('table'))
+export const hoverContext = createContext(Symbol('hover-row'))
+
+@customElement('data-table')
+export class DataTable<T extends { id: number }> extends LitElement {
+  @state()
+  protected _page = 1
+
+  @state()
+  @provide({ context: dataContext })
+  protected _items: T[] = []
+
+  @state()
+  @provide({ context: hoverContext })
+  protected _hover: number | undefined
+
+  @state()
+  protected _totalPages = 0
+
+  @property()
+  src: string
+
+  @property()
+  colwidths = ''
+
+  onHoverItem(e: HoverItemEvent) {
+    this._hover = e.detail
+  }
+
+  async connectedCallback() {
+    super.connectedCallback()
+    await this.fetchData()
+  }
+
+  async fetchData() {
+    const perPage = 10
+
+    const url = new URL(`${import.meta.env.VITE_API_HOST}${this.src}`)
+    url.searchParams.set('limit', String(perPage))
+    url.searchParams.set('offset', String((this._page - 1) * perPage))
+
+    try {
+      const res = await fetch(url)
+      const data = await res.json()
+      this._items = data.results
+      this._totalPages = Math.floor(data.total / perPage) + 1
+    } catch (error) {
+      console.error(error)
+    }
+  }
+
+  prev() {
+    this._page += 1
+    this.fetchData()
+  }
+
+  next() {
+    this._page -= 1
+    this.fetchData()
+  }
+
+  render() {
+    const pagination = html`   
+    <span class="mr-1">Page ${this._page} of ${this._totalPages}</span>
+    <button @click="${this.next}" .disabled=${this._page === 1}>Prev</button>
+    <button @click="${this.prev}" .disabled=${this._page === this._totalPages}>Next</button>
+    `
+
+    return html`
+    <div class="table" style="--colwidths: ${this.colwidths}" @hoverItem=${this.onHoverItem}>
+      <slot></slot>
+      <footer>
+        ${pagination}
+      </footer>
+    </div>
+    `
+  }
+
+  static styles = css`
+    ${unsafeCSS(resetcss)}
+    ${unsafeCSS(btncss)}
+
+    .table {
+      display: grid;
+      grid-template-columns: var(--colwidths, "");
+      border-radius: 0.25rem;
+      border: 1px solid var(--gray-100);
+    }
+
+    footer {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 0 1rem;
+      height: 3rem;
+      background-color: var(--gray-50);
+      grid-column: 1/-1;
+      gap: 0.25rem
+    }
+    `
+}
+
+@customElement('dt-col')
+export class DataTableColumn<T extends { id: number }> extends LitElement {
+  @consume({ context: dataContext, subscribe: true })
+  @state()
+  protected _items: T[] = []
+
+  @consume({ context: hoverContext, subscribe: true })
+  @state()
+  protected _hover: number | undefined
+
+  @property()
+  title: string
+
+  @property()
+  key: keyof T
+
+  @property()
+  align: 'left' | 'right' | 'center' = 'left'
+
+  hoverItem(id: number | undefined) {
+    this.dispatchEvent(
+      new CustomEvent('hoverItem', {
+        detail: id,
+        bubbles: true,
+
+        composed: true,
+      })
+    )
+  }
+
+  render() {
+    return html`
+    <div class="th" style="text-align: ${this.align}">
+        ${this.title}
+    </div>
+    ${repeat(
+      this._items,
+      (item) => html`
+      <div class="td ${this._hover === item.id ? 'hover' : ''}" style="text-align: ${this.align}" @mouseenter=${() => this.hoverItem(item.id)} @mouseleave=${() => this.hoverItem(undefined)}>${item[this.key]}</div>
+        `
+    )}
+    `
+  }
+
+  static styles = css`
+    ${unsafeCSS(resetcss)}
+    
+    :host {
+      width: 1fr
+    }
+
+    .th {
+      display: flex;
+      align-items: center;
+      padding: 0 1rem;
+      height: 3rem;
+      font-weight: bold;
+      background-color: var(--gray-50);
+      border-bottom: 1px solid var(--gray-100);
+    }
+
+    .td {
+      display: flex;
+      align-items: center;
+      padding: 0 1rem;
+      height: 3rem;
+      border-bottom: 1px solid var(--gray-100);
+      cursor: pointer;
+
+      &.hover {
+        background-color: var(--gray-50);
+        color: var(--blue-700);
+      }
+    }
+    `
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'data-table': DataTable<{ id: number }>
+    'dt-col': DataTableColumn<{ id: number }>
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "@fooloomanzoo/datetime-picker": "^3.0.9",
-    "@lit/context": "^1.1.2",
+    "@lit/context": "^1.1.3",
     "class-transformer": "^0.5.1",
     "leaflet": "^1.9.4",
     "lit": "^3.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.0.9
         version: 3.0.9
       '@lit/context':
-        specifier: ^1.1.2
-        version: 1.1.2
+        specifier: ^1.1.3
+        version: 1.1.3
       class-transformer:
         specifier: ^0.5.1
         version: 0.5.1
@@ -407,8 +407,8 @@ packages:
   '@lit-labs/ssr-dom-shim@1.2.0':
     resolution: {integrity: sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==}
 
-  '@lit/context@1.1.2':
-    resolution: {integrity: sha512-S0nw2C6Tkm7fVX5TGYqeROGD+Z9Coa2iFpW+ysYBDH3YvCqOY3wVQvSgwbaliLJkjTnSEYCBe9qFqKV8WUFpVw==}
+  '@lit/context@1.1.3':
+    resolution: {integrity: sha512-Auh37F4S0PZM93HTDfZWs97mmzaQ7M3vnTc9YvxAGyP3UItSK/8Fs0vTOGT+njuvOwbKio/l8Cx/zWL4vkutpQ==}
 
   '@lit/reactive-element@2.0.4':
     resolution: {integrity: sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==}
@@ -1927,7 +1927,7 @@ snapshots:
 
   '@lit-labs/ssr-dom-shim@1.2.0': {}
 
-  '@lit/context@1.1.2':
+  '@lit/context@1.1.3':
     dependencies:
       '@lit/reactive-element': 2.0.4
 


### PR DESCRIPTION
This adds a new component for making tables easier. The motivation behind this is that there will be lots of code duplication otherwise, once I start adding tables for other data in openfish, such as users or species.

**Usage:**
```html
<data-table src="/api/v1/capturesources" colwidths="2fr 3fr 2fr 2fr">
  <dt-col title="Name" key="name"></dt-col>
  <dt-col title="Camera Hardware" key="camera_hardware"></dt-col>
  <dt-col title="Site ID" key="site_id"></dt-col>
  <dt-col title="Location" key="location"></dt-col>
</data-table>
```