### PR TITLE
Remove environmental variable VITE_API_HOST and use Vite's proxy 

### DIFF
--- a/openfish-webapp/.env
+++ b/openfish-webapp/.env
@@ -1,2 +1,0 @@
-# VITE_API_HOST=http://localhost:8080
-VITE_API_HOST=https://openfish.appspot.com

--- a/openfish-webapp/capturesources.html
+++ b/openfish-webapp/capturesources.html
@@ -39,7 +39,7 @@
     async function deleteCaptureSource(id) {
       try {
         await fetch(
-          `${import.meta.env.VITE_API_HOST}/api/v1/capturesources/${id}`, { method: 'DELETE' }
+          `/api/v1/capturesources/${id}`, { method: 'DELETE' }
         )
         dataTable.fetchData()
       } catch (error) {

--- a/openfish-webapp/src/webcomponents/capture-source-dropdown.ts
+++ b/openfish-webapp/src/webcomponents/capture-source-dropdown.ts
@@ -17,7 +17,7 @@ export class CaptureSourceDropdown extends LitElement {
 
   async fetchData() {
     try {
-      const res = await fetch(`${import.meta.env.VITE_API_HOST}/api/v1/capturesources?limit=999`)
+      const res = await fetch('/api/v1/capturesources?limit=999')
       const data = (await res.json()) as Result<CaptureSource>
       this._items = data.results
     } catch (error) {

--- a/openfish-webapp/src/webcomponents/capturesource-list.ts
+++ b/openfish-webapp/src/webcomponents/capturesource-list.ts
@@ -31,9 +31,7 @@ export class CaptureSourceList extends LitElement {
       params.set('limit', String(10))
       params.set('offset', String((this._page - 1) * perPage))
 
-      const res = await fetch(
-        `${import.meta.env.VITE_API_HOST}/api/v1/capturesources?${params.toString()}`
-      )
+      const res = await fetch(`/api/v1/capturesources?${params.toString()}`)
       const data = (await res.json()) as Result<CaptureSource>
       this._items = data.results
       this._totalPages = Math.floor(data.total / perPage)

--- a/openfish-webapp/src/webcomponents/data-table.ts
+++ b/openfish-webapp/src/webcomponents/data-table.ts
@@ -46,7 +46,7 @@ export class DataTable<T extends { id: number }> extends LitElement {
   async fetchData() {
     const perPage = 10
 
-    const url = new URL(`${import.meta.env.VITE_API_HOST}${this.src}`)
+    const url = new URL(this.src)
     url.searchParams.set('limit', String(perPage))
     url.searchParams.set('offset', String((this._page - 1) * perPage))
 

--- a/openfish-webapp/src/webcomponents/form-dialog.ts
+++ b/openfish-webapp/src/webcomponents/form-dialog.ts
@@ -50,7 +50,7 @@ export class FormDialog extends LitElement {
 
     e.target.reset()
 
-    await fetch(`${import.meta.env.VITE_API_HOST}${this.action}`, {
+    await fetch(this.action, {
       method: this.method,
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),

--- a/openfish-webapp/src/webcomponents/observation-editor.ts
+++ b/openfish-webapp/src/webcomponents/observation-editor.ts
@@ -127,9 +127,7 @@ export class SpeciesSelection extends AbstractObservationEditor {
       if (this._search.length > 0) {
         params.set('search', this._search)
       }
-      const res = await fetch(
-        `${import.meta.env.VITE_API_HOST}/api/v1/species/recommended?${params}`
-      )
+      const res = await fetch(`/api/v1/species/recommended?${params}`)
       this._speciesList.push(...(await res.json()).results)
       this.offset += 20
       this.requestUpdate()

--- a/openfish-webapp/src/webcomponents/stream-list.ts
+++ b/openfish-webapp/src/webcomponents/stream-list.ts
@@ -43,9 +43,7 @@ export class StreamList extends LitElement {
         params.set(key, String(this._filter[key as keyof Filter]))
       }
 
-      const res = await fetch(
-        `${import.meta.env.VITE_API_HOST}/api/v1/videostreams?${params.toString()}`
-      )
+      const res = await fetch(`/api/v1/videostreams?${params.toString()}`)
       const data = (await res.json()) as Result<VideoStream>
       this._items = data.results
       this._totalPages = Math.floor(data.total / perPage)

--- a/openfish-webapp/src/webcomponents/user-provider.ts
+++ b/openfish-webapp/src/webcomponents/user-provider.ts
@@ -17,7 +17,7 @@ export class UserProvider extends LitElement {
       this.user = plainToInstance(User, { email: 'user@localhost', role: 'admin' })
     } else {
       try {
-        const res = await fetch(`${import.meta.env.VITE_API_HOST}/api/v1/auth/me`)
+        const res = await fetch('/api/v1/auth/me')
         const json = await res.json()
         this.user = plainToInstance(User, json)
       } catch (error) {

--- a/openfish-webapp/src/webcomponents/watch-stream.ts
+++ b/openfish-webapp/src/webcomponents/watch-stream.ts
@@ -109,7 +109,7 @@ export class WatchStream extends LitElement {
     }
 
     // Make annotation.
-    await fetch(`${import.meta.env.VITE_API_HOST}/api/v1/annotations`, {
+    await fetch('/api/v1/annotations', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
@@ -132,7 +132,7 @@ export class WatchStream extends LitElement {
   async fetchVideoStream(id: number) {
     try {
       // Fetch video stream with ID.
-      const res = await fetch(`${import.meta.env.VITE_API_HOST}/api/v1/videostreams/${id}`)
+      const res = await fetch(`/api/v1/videostreams/${id}`)
       this._videostream = (await res.json()) as VideoStream
     } catch (error) {
       console.error(error) // TODO: handle errors.
@@ -143,9 +143,7 @@ export class WatchStream extends LitElement {
       // Fetch annotations for this video stream.
       // TODO: We should only fetch a small portion of the annotations near the current playback position.
       //       When the user plays the video we can fetch in more as needed.
-      const res = await fetch(
-        `${import.meta.env.VITE_API_HOST}/api/v1/annotations?videostream=${id}&order=StartTime`
-      )
+      const res = await fetch(`/api/v1/annotations?videostream=${id}&order=StartTime`)
       const json = await res.json()
       this._annotations = plainToInstance<Annotation, object[]>(Annotation, json.results)
       console.log(this._annotations)

--- a/openfish-webapp/vite.config.ts
+++ b/openfish-webapp/vite.config.ts
@@ -19,4 +19,12 @@ export default defineConfig({
       input,
     },
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8080',
+        changeOrigin: true,
+      },
+    },
+  },
 })


### PR DESCRIPTION
Remove environmental variable VITE_API_HOST and use Vite's proxy during development

This makes things simpler and makes the development environment closer to what is on the live site, by putting the /api endpoints on the same origin.