### PR TITLE
Deploy openfish only on tagged releases

### DIFF
--- a/.github/workflows/deploy-openfish.yaml
+++ b/.github/workflows/deploy-openfish.yaml
@@ -3,6 +3,8 @@ name: Deploy OpenFish to Google AppEngine
 on:
   push:
     branches: [master]
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Currently, openfish is being deployed automatically on every push to master, which is too much. Instead, it now is deployed only when we tag a release