### PR TITLE
Add functionality to filter annotations by video stream ID

### DIFF
--- a/cmd/openfish/handlers/annotations.go
+++ b/cmd/openfish/handlers/annotations.go
@@ -96,10 +96,11 @@ func FromAnnotation(annotation *entities.Annotation, id int64, format *api.Forma
 
 // GetAnnotationsQuery describes the URL query parameters required for the GetAnnotations endpoint.
 type GetAnnotationsQuery struct {
-	TimeSpan      *string           `query:"timespan"`       // Optional. TODO: choose more appropriate type.
-	CaptureSource *int64            `query:"capture_source"` // Optional.
-	Observer      *string           `query:"observer"`       // Optional.
-	Observation   map[string]string `query:"observation"`    // Optional.
+	TimeSpan      *string           `query:"timespan"`      // Optional. TODO: choose more appropriate type.
+	CaptureSource *int64            `query:"capturesource"` // Optional.
+	VideoStream   *int64            `query:"videostream"`   // Optional.
+	Observer      *string           `query:"observer"`      // Optional.
+	Observation   map[string]string `query:"observation"`   // Optional.
 	api.LimitAndOffset
 	api.Format
 	api.Sort
@@ -191,7 +192,7 @@ func GetAnnotations(ctx *fiber.Ctx) error {
 	}
 
 	// Fetch data from the datastore.
-	annotations, ids, err := services.GetAnnotations(qry.Limit, qry.Offset, qry.Observer, qry.Observation, qry.Order)
+	annotations, ids, err := services.GetAnnotations(qry.Limit, qry.Offset, qry.VideoStream, qry.Observer, qry.Observation, qry.Order)
 	if err != nil {
 		return api.DatastoreReadFailure(err)
 	}

--- a/cmd/openfish/services/annotations.go
+++ b/cmd/openfish/services/annotations.go
@@ -92,10 +92,15 @@ func AnnotationExists(id int64) bool {
 }
 
 // GetAnnotations gets a list of annotations, filtering by timespan, capturesource, observer & observation if specified.
-func GetAnnotations(limit int, offset int, observer *string, observation map[string]string, order *string) ([]entities.Annotation, []int64, error) {
+func GetAnnotations(limit int, offset int, videostream *int64, observer *string, observation map[string]string, order *string) ([]entities.Annotation, []int64, error) {
 	// Fetch data from the datastore.
 	store := ds_client.Get()
 	query := store.NewQuery(entities.ANNOTATION_KIND, false)
+
+	// Filter by videostream.
+	if videostream != nil {
+		query.FilterField("VideoStreamID", "=", *videostream)
+	}
 
 	// Filter by observer.
 	if observer != nil {

--- a/index.yaml
+++ b/index.yaml
@@ -1,0 +1,50 @@
+# AUTHORS
+#   Scott Barnard <scott@ausocean.org>
+#
+# LICENSE
+#   Copyright (c) 2024, The OpenFish Contributors.
+#
+#   Redistribution and use in source and binary forms, with or without
+#   modification, are permitted provided that the following conditions are met:
+#
+#   1. Redistributions of source code must retain the above copyright notice, this
+#      list of conditions and the following disclaimer.
+#
+#   2. Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+#   3. Neither the name of The Australian Ocean Lab Ltd. ("AusOcean")
+#      nor the names of its contributors may be used to endorse or promote
+#      products derived from this software without specific prior written permission.
+#
+#   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+#   DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+#   FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+#   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+#   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+#   CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+#   OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#   OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+#
+#
+# Here we define our composite indices for Google Datastore so we can efficiently
+# filter and sort on multiple fields.
+#
+# Command to update indices:
+# gcloud datastore indexes create index.yaml --project openfish
+#
+# See also::
+# https://cloud.google.com/datastore/docs/tools/indexconfig
+#
+
+indexes:
+
+- kind: Annotation
+  properties:
+  - name: VideoStreamID
+  - name: StartTime
+


### PR DESCRIPTION
Filtering by video stream ID was not implemented so when viewing video streams on openfish, annotations from other videos would appear.