### PR TITLE
Support editing capture sources

### DIFF
--- a/cmd/openfish/handlers/capturesource.go
+++ b/cmd/openfish/handlers/capturesource.go
@@ -273,7 +273,8 @@ func UpdateCaptureSource(ctx *fiber.Ctx) error {
 
 	var lat, long *float64
 	if body.Location != nil {
-		*lat, *long, err = parseGeoPoint(*body.Location)
+		la, lo, err := parseGeoPoint(*body.Location)
+		lat, long = &la, &lo
 		if err != nil {
 			return api.InvalidRequestJSON(err)
 		}

--- a/openfish-webapp/admin/capturesources.html
+++ b/openfish-webapp/admin/capturesources.html
@@ -38,10 +38,15 @@
     </style>
 
     <script type="module" >
-    const createCaptureSourceDialog = document.querySelector("form-dialog")
+    const createDialog = document.querySelector("form-dialog.create")
+    const editDialog = document.querySelector("form-dialog.edit")
     const confirmDialog= document.querySelector("confirm-dialog")
     const createBtn = document.querySelector("#create-btn")
     const dt = document.querySelector("data-table")
+    const nameInput = editDialog.shadowRoot.querySelector("#name")
+    const cameraHardwareInput = editDialog.shadowRoot.querySelector("#camera_hardware")
+    const siteIdInput = editDialog.shadowRoot.querySelector("#site_id")
+    const locationInput = editDialog.shadowRoot.querySelector("#location")
 
     async function deleteCaptureSource(item) {
       try {
@@ -52,9 +57,18 @@
       }
     }
 
-    createBtn.addEventListener("click", () => createCaptureSourceDialog.show())
-    createCaptureSourceDialog.addEventListener("formsubmit", () => dt.fetchData())
-    dt.addEventListener("deleteitem", (e) => confirmDialog.show(()=> deleteCaptureSource(e.detail)))    
+    createBtn.addEventListener("click", () => createDialog.show())
+    createDialog.addEventListener("formsubmit", () => dt.fetchData())
+    dt.addEventListener("deleteitem", (e) => confirmDialog.show(()=> deleteCaptureSource(e.detail)))
+    dt.addEventListener("edititem", (e) => {
+        nameInput.value = e.detail.name
+        cameraHardwareInput.value = e.detail.camera_hardware
+        siteIdInput.value = e.detail.site_id ?? ''
+        locationInput.value = e.detail.location
+        editDialog.action=`/api/v1/capturesources/${e.detail.id}`
+        editDialog.show()
+      })
+      editDialog.addEventListener("formsubmit", () => dt.fetchData())    
     </script>
   </head>
   <body class="grid-layout">
@@ -72,17 +86,32 @@
           <h2>Manage capture sources</h2>
           <button class="btn btn-blue" id="create-btn">+ Create new capture source</button>
         </header>
-        <data-table src="/api/v1/capturesources" colwidths="2fr 3fr 2fr 2fr min-content">
+        <data-table src="/api/v1/capturesources" colwidths="2fr 3fr 2fr 2fr min-content min-content">
           <dt-col title="Name" key="name"></dt-col>
           <dt-col title="Camera Hardware" key="camera_hardware"></dt-col>
           <dt-col title="Site ID" key="site_id"></dt-col>
           <dt-col title="Location" key="location"></dt-col>
+          <dt-btn action="edititem" text="Edit"></dt-btn>
           <dt-btn action="deleteitem" text="Delete"></dt-btn>
         </data-table>  
       </main>
 
       <confirm-dialog>Are you sure you want to delete this capture source?</confirm-dialog>
-      <form-dialog action="/api/v1/capturesources" title="Create new capture source" btntext="Create" >
+      <form-dialog class="create" action="/api/v1/capturesources" title="Create new capture source" btntext="Create" >
+        <label for="name">Name</label>
+        <input type="text" id="name" name="name" placeholder="Enter name of the capture source" required />
+
+        <label for="camera_hardware">Camera Hardware</label>
+        <input type="text" id="camera_hardware" name="camera_hardware" placeholder="Enter description of camera hardware" required />
+
+        <label for="site_id">Site ID</label>
+        <input type="text" id="site_id" name="site_id" placeholder="Enter site ID (optional)"  />
+
+        <label for="location">Location</label>
+        <location-picker id="location" name="location" ></location-picker>
+      </form-dialog>
+
+      <form-dialog class="edit" method="PATCH" action="/api/v1/capturesources" title="Edit capture source" btntext="Save changes" >
         <label for="name">Name</label>
         <input type="text" id="name" name="name" placeholder="Enter name of the capture source" required />
 


### PR DESCRIPTION
This adds a new button for editing a capture source which brings up a dialog where you can change its location, name, site ID and camera hardware description

Also fixes a nil dereference error when updating a capture source

![image](https://github.com/user-attachments/assets/3c932ad3-fe71-4845-a7a4-4c27fe7eab98)
