### PR TITLE
Support editing video streams

### DIFF
--- a/openfish-webapp/admin/videostreams.html
+++ b/openfish-webapp/admin/videostreams.html
@@ -39,10 +39,15 @@
       }
     </style>
     <script type="module" >
-      const createCaptureSourceDialog = document.querySelector("form-dialog")
+      const createDialog = document.querySelector("form-dialog.create")
+      const editDialog = document.querySelector("form-dialog.edit")
       const confirmDialog= document.querySelector("confirm-dialog")
       const createBtn = document.querySelector("#create-btn")
       const dt = document.querySelector("data-table")
+      const captureSourceSelect = editDialog.shadowRoot.querySelector("#capturesource")
+      const streamUrlInput = editDialog.shadowRoot.querySelector("#stream_url")
+      const startTimeInput = editDialog.shadowRoot.querySelector("#startTime")
+      const endTimeInput = editDialog.shadowRoot.querySelector("#endTime")
 
       async function deleteCaptureSource(item) {
         try {
@@ -53,9 +58,18 @@
         }
       }
   
-      createBtn.addEventListener("click", () => createCaptureSourceDialog.show())
-      createCaptureSourceDialog.addEventListener("formsubmit", () => dt.fetchData())
+      createBtn.addEventListener("click", () => createDialog.show())
+      createDialog.addEventListener("formsubmit", () => dt.fetchData())
       dt.addEventListener("deleteitem", (e) => confirmDialog.show(()=> deleteCaptureSource(e.detail)))
+      dt.addEventListener("edititem", (e) => {
+        captureSourceSelect.value = e.detail.capturesource
+        streamUrlInput.value = e.detail.stream_url
+        startTimeInput.value = e.detail.startTime
+        endTimeInput.value = e.detail.endTime
+        editDialog.action=`/api/v1/videostreams/${e.detail.id}`
+        editDialog.show()
+      })
+      editDialog.addEventListener("formsubmit", () => dt.fetchData())    
     </script>
   </head>
   <body class="grid-layout">
@@ -74,19 +88,35 @@
           <button class="btn btn-blue" id="create-btn">+ Register video stream</button>
         </header>
 
-        <data-table src="/api/v1/videostreams" colwidths="3fr 1fr 1fr 1fr min-content">
+        <data-table src="/api/v1/videostreams" colwidths="3fr 1fr 1fr 1fr min-content min-content">
           <dt-col title="Stream URL" key="stream_url"></dt-col>
           <dt-col title="Start Time" key="startTime"></dt-col>
           <dt-col title="End Time" key="endTime"></dt-col>
           <dt-col title="Capture source" key="capturesource"></dt-col>
+          <dt-btn action="edititem" text="Edit"></dt-btn>
           <dt-btn action="deleteitem" text="Delete"></dt-btn>
         </data-table>  
 
         <confirm-dialog>Are you sure you want to delete this video stream?</confirm-dialog>
-        <form-dialog action="/api/v1/videostreams" title="Register a new video stream" btntext="Register" >
+        <form-dialog class="create" action="/api/v1/videostreams" title="Register a new video stream" btntext="Register" >
           
           <label for="capturesource">Capture Source</label>
-          <data-select name="capturesource" src="/api/v1/capturesources"></data-select>
+          <data-select name="capturesource" id="capturesource" src="/api/v1/capturesources"></data-select>
+
+          <label for="stream_url">Stream URL</label>
+          <input type="url" id="stream_url" name="stream_url" placeholder="Enter the URL of the video stream" required/>
+
+          <label for="startTime">Start Time <client-timezone></client-timezone></label>
+          <input-datetime name="startTime" id="startTime" required></input-datetime>
+          
+          <label for="endTime">End Time <client-timezone></client-timezone></label>
+          <input-datetime name="endTime" id="endTime" required></input-datetime>
+          
+        </form-dialog>
+        <form-dialog class="edit" method="PATCH" action="/api/v1/videostreams" title="Edit video stream" btntext="Save changes" >
+          
+          <label for="capturesource">Capture Source</label>
+          <data-select name="capturesource" id="capturesource" src="/api/v1/capturesources"></data-select>
 
           <label for="stream_url">Stream URL</label>
           <input type="url" id="stream_url" name="stream_url" placeholder="Enter the URL of the video stream" required/>

--- a/openfish-webapp/src/utils/datetime.ts
+++ b/openfish-webapp/src/utils/datetime.ts
@@ -5,7 +5,14 @@ export function datetimeDifference(a: DateLike, b: DateLike): number {
   return (new Date(a).getTime() - new Date(b).getTime()) / 1000
 }
 
-// A Date or ISO string representation of a date.
+// toDatetimeLocal converts a Date to a format <input type="datetime-local"> can accept as a value.
+export function toDatetimeLocal(dt: DateLike): string {
+  const date = new Date(dt)
+  date.setMinutes(date.getMinutes() - date.getTimezoneOffset())
+  return date.toISOString().slice(0, 16)
+}
+
+// A Date or RFC3339 string representation of a date.
 export type DateLike = Date | string
 
 export function formatAsDate(dt: DateLike): string {

--- a/openfish-webapp/src/webcomponents/data-select.ts
+++ b/openfish-webapp/src/webcomponents/data-select.ts
@@ -22,7 +22,7 @@ export class DataSelect<T extends NamedItem> extends LitElement {
   pkey = 'id'
 
   @property()
-  value = ''
+  value: string
 
   @property()
   defaultText = 'Please select'
@@ -61,7 +61,7 @@ export class DataSelect<T extends NamedItem> extends LitElement {
   render() {
     return html`
     <select @input=${this.onInput} .name=${this.name} .value=${this.value}>
-    <option .value=${''}>${this.defaultText}</option>
+    <option value="">${this.defaultText}</option>
     ${repeat(
       this._items,
       (item: T) => html`<option .value=${item[this.pkey]}>${item.name}</option>`

--- a/openfish-webapp/src/webcomponents/input-datetime.ts
+++ b/openfish-webapp/src/webcomponents/input-datetime.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
+import { toDatetimeLocal } from '../utils/datetime'
 
 // An input element that wraps an <input type="datetime-local">
 // but returns a date in RFC 3339 format, using the client's default
@@ -32,7 +33,7 @@ export class InputDatetime extends LitElement {
   }
 
   render() {
-    return html`<input type="datetime-local" @input=${this.onInput} .name=${this.name} .value=${this.value} .required=${this.required}>`
+    return html`<input type="datetime-local" @input=${this.onInput} .name=${this.name} .value=${toDatetimeLocal(this.value)} .required=${this.required}>`
   }
 
   static styles = css`


### PR DESCRIPTION
This adds a new button for editing a video stream which brings up a dialog where you can change its start and end time, reasssign its capture source and update its stream URL. Like creating videostreams, this handles the local user's timezone, performing conversions as needed. For reviewers it will show Australia/Adelaide instead.

![image](https://github.com/user-attachments/assets/e81a863b-36c1-436a-9c8b-890098f81d75)
