### PR TITLE
services/annotations: check species before adding to annotation

### DIFF
--- a/cmd/openfish/services/annotations.go
+++ b/cmd/openfish/services/annotations.go
@@ -36,6 +36,7 @@ package services
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/ausocean/openfish/cmd/openfish/entities"
 	"github.com/ausocean/openfish/cmd/openfish/globals"
@@ -288,6 +289,15 @@ func CreateAnnotation(contents AnnotationContents) (*Annotation, error) {
 func AddIdentification(id int64, userID int64, speciesID int64) error {
 	// Update data in the datastore.
 	store := globals.GetStore()
+
+	// Check if speciesID exists.
+	speciesKey := store.IDKey(entities.SPECIES_KIND, speciesID)
+	var species entities.Species
+	if err := store.Get(context.Background(), speciesKey, &species); err != nil {
+		return fmt.Errorf("species ID %d does not exist", speciesID)
+	}
+
+	// Proceed with adding identification.
 	key := store.IDKey(entities.ANNOTATION_KIND, id)
 	var annotation entities.Annotation
 

--- a/cmd/openfish/services/annotations.go
+++ b/cmd/openfish/services/annotations.go
@@ -291,9 +291,7 @@ func AddIdentification(id int64, userID int64, speciesID int64) error {
 	store := globals.GetStore()
 
 	// Check if speciesID exists.
-	speciesKey := store.IDKey(entities.SPECIES_KIND, speciesID)
-	var species entities.Species
-	if err := store.Get(context.Background(), speciesKey, &species); err != nil {
+	if !SpeciesExists(speciesID) {
 		return fmt.Errorf("species ID %d does not exist", speciesID)
 	}
 

--- a/cmd/openfish/services/annotations_test.go
+++ b/cmd/openfish/services/annotations_test.go
@@ -187,11 +187,6 @@ func TestAnnotationAddIdentification(t *testing.T) {
 }
 
 func TestAnnotationAddNonExistingSpeciesIdentification(t *testing.T) {
-	// TODO: Run test in CI when issue is fixed.
-	if testing.Short() {
-		t.Skip("skipping testing in short mode")
-	}
-
 	setup()
 	original := createTestAnnotation()
 	uid, _ := services.CreateUser(services.UserContents{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,8 +90,8 @@ importers:
         specifier: ^1.1.4
         version: 1.1.5
       '@openfish/client':
-        specifier: github:ausocean/openfish#path:/client
-        version: https://codeload.github.com/ausocean/openfish/tar.gz/cc6bf660216efc96ce742009905e65937466467c#path:/client
+        specifier: workspace:*
+        version: link:../client
       '@tailwindcss/forms':
         specifier: ^0.5.10
         version: 0.5.10(tailwindcss@4.1.7)
@@ -662,10 +662,6 @@ packages:
 
   '@lit/reactive-element@2.1.0':
     resolution: {integrity: sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==}
-
-  '@openfish/client@https://codeload.github.com/ausocean/openfish/tar.gz/cc6bf660216efc96ce742009905e65937466467c#path:/client':
-    resolution: {path: /client, tarball: https://codeload.github.com/ausocean/openfish/tar.gz/cc6bf660216efc96ce742009905e65937466467c}
-    version: 0.0.0
 
   '@polymer/iron-a11y-keys-behavior@3.0.1':
     resolution: {integrity: sha512-lnrjKq3ysbBPT/74l0Fj0U9H9C35Tpw2C/tpJ8a+5g8Y3YJs1WSZYnEl1yOkw6sEyaxOq/1DkzH0+60gGu5/PQ==}
@@ -2387,10 +2383,6 @@ snapshots:
   '@lit/reactive-element@2.1.0':
     dependencies:
       '@lit-labs/ssr-dom-shim': 1.3.0
-
-  '@openfish/client@https://codeload.github.com/ausocean/openfish/tar.gz/cc6bf660216efc96ce742009905e65937466467c#path:/client':
-    dependencies:
-      openapi-fetch: 0.13.8
 
   '@polymer/iron-a11y-keys-behavior@3.0.1':
     dependencies:

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "tailwindcss": "^4.1.2",
     "@tailwindcss/forms": "^0.5.10",
     "@tailwindcss/vite": "^4.1.2",
-    "@openfish/client": "github:ausocean/openfish#path:/client"
+    "@openfish/client": "workspace:*"
   },
   "peerDependencies": {
     "typescript": "^5.8.2",


### PR DESCRIPTION
This was done to make a test pass. Namely TestAnnotationAddNonExistingSpeciesIdentification. This can be skipped with the -short flag but I didn't realise that. It's fixed now so it's no longer behind the flag.