### PR TITLE
cmd/openfish/services: return ErrNoSuchEntity if no user found by email

### DIFF
--- a/cmd/openfish/services/users.go
+++ b/cmd/openfish/services/users.go
@@ -130,8 +130,8 @@ func GetUserByEmail(email string) (*User, error) {
 		return nil, err
 	}
 
-	if len(keys) == 0 {
-		return nil, nil
+	if len(keys) == 0 || len(users) == 0 {
+		return nil, datastore.ErrNoSuchEntity
 	}
 
 	return &User{


### PR DESCRIPTION
This was done because the TestGetUserByEmail function was panicing due to assuming this function returns a valid user or an error.

See issue #331 