### PR TITLE
services: stop tests before panicking

### DIFF
--- a/cmd/openfish/services/users_test.go
+++ b/cmd/openfish/services/users_test.go
@@ -50,7 +50,7 @@ func TestCreateUser(t *testing.T) {
 		Role:        role.Default,
 	})
 	if err != nil {
-		t.Errorf("Could not create user entity %s", err)
+		t.Fatalf("Could not create user entity %s", err)
 	}
 }
 
@@ -92,7 +92,7 @@ func TestGetUserByID(t *testing.T) {
 
 	user, err := services.GetUserByID(id)
 	if err != nil {
-		t.Errorf("Could not get user entity %s", err)
+		t.Fatalf("Could not get user entity %s", err)
 	}
 
 	if user.ID != id {
@@ -120,7 +120,7 @@ func TestGetUserByEmail(t *testing.T) {
 
 	user, err := services.GetUserByEmail("coral.fischer@example.com")
 	if err != nil {
-		t.Errorf("Could not get user entity %s", err)
+		t.Fatalf("Could not get user entity %s", err)
 	}
 
 	if user.DisplayName != contents.DisplayName {
@@ -152,7 +152,7 @@ func TestUpdateUser(t *testing.T) {
 		Role: &role,
 	})
 	if err != nil {
-		t.Errorf("Could not update user entity %s", err)
+		t.Fatalf("Could not update user entity %s", err)
 	}
 
 	user, _ := services.GetUserByID(id)
@@ -166,7 +166,7 @@ func TestUpdateUser(t *testing.T) {
 		DisplayName: &displayName,
 	})
 	if err != nil {
-		t.Errorf("Could not update user entity %s", err)
+		t.Fatalf("Could not update user entity %s", err)
 	}
 
 	user, _ = services.GetUserByID(id)
@@ -200,7 +200,7 @@ func TestDeleteUser(t *testing.T) {
 	// Delete the capture source entity.
 	err := services.DeleteUser(id)
 	if err != nil {
-		t.Errorf("Could not delete user entity")
+		t.Fatalf("Could not delete user entity: %s", err)
 	}
 
 	// Check if the capture source exists.


### PR DESCRIPTION
This was done because the test would panic occasionally. First step is to not let it panic.

The panic I'm referring to is #346 .