### PR TITLE
ui: variable aspect ratio

### DIFF
--- a/site/watch.html
+++ b/site/watch.html
@@ -47,7 +47,7 @@
                 <h1 class="text-2xl font-bold text-blue-200 ml-4">Watching stream: <span class="stream-id">-</span></h1>
             </header>
 
-            <div class="px-4 contain" style="height: calc(100vh - 12.75rem);">
+            <div class="px-4 mx-auto max-w-9/10 flex justify-center" style="height: calc(100vh - 12.75rem);">
                 <watch-stream class="mx-auto h-full block"></watch-stream>
             </div>
 


### PR DESCRIPTION
This is because our newer cameras use 16:9 and the player uses 4:3. This uses the youtube oembed api get an approximate aspect ratio (it is difficult to find the actual video resolution to get a more accurate aspect ratio). Resolves #178.
<img width="1900" height="950" alt="image" src="https://github.com/user-attachments/assets/13468d71-7ee6-4886-adad-cd05ec109a16" />
<img width="1900" height="950" alt="image" src="https://github.com/user-attachments/assets/da03a354-fd3e-488f-b7c9-a27f8c4d2ccf" />
