### PR TITLE
cmd: Create user if they doesn't exist when using IAP

### DIFF
--- a/cmd/openfish/middleware/authentication.go
+++ b/cmd/openfish/middleware/authentication.go
@@ -88,7 +88,7 @@ func ValidateJWT(aud string) func(*fiber.Ctx) error {
 		user, err := services.GetUserByEmail(email)
 		if err != nil {
 			if errors.Is(err, datastore.ErrNoSuchEntity) {
-				userContents := services.UserContents{DisplayName: strings.Split(email, "@")[0], Email: email}
+				userContents := services.UserContents{DisplayName: strings.Split(email, "@")[0], Email: email, Role: role.Readonly}
 				userId, err := services.CreateUser(userContents)
 				if err != nil {
 					return err


### PR DESCRIPTION
This allows a new user to log in without having to manually create the user in the datastore.